### PR TITLE
Update to mariadb connector

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,8 +109,12 @@ dependencies {
     compile group: 'commons-fileupload', name: 'commons-fileupload', version: '1.3.3'
     compile group: 'joda-time', name: 'joda-time', version: '2.10'
     compile 'org.grails.plugins:quartz:2.0.13'
-    compile group: 'mysql', name: 'mysql-connector-java', version: '8.0.13'
+
+    // DB Libraries
+    compile group: 'org.mariadb.jdbc', name: 'mariadb-java-client', version: '2.3.0'
     compile 'org.grails.plugins:database-migration:3.0.4'
+    compile 'org.liquibase:liquibase-core:3.6.2'
+
     // Broad's crowd server only likes TLSv1 HttpBuilder is very forgiving wrt ssl protocols
     compile group: 'org.codehaus.groovy.modules.http-builder', name: 'http-builder', version: '0.7.1'
     compile group: 'io.github.http-builder-ng', name: 'http-builder-ng-okhttp', version: '1.0.3'

--- a/src/main/config/application.yml.ctmpl
+++ b/src/main/config/application.yml.ctmpl
@@ -103,10 +103,10 @@ environments:
         statusUrl: http://bsp/BSP/
     dataSource:
       pooled: true
-      driverClassName: com.mysql.jdbc.Driver
+      driverClassName: org.mariadb.jdbc.Driver
       username: {{$orsp.Data.dev_ds_username}}
       password: {{$orsp.Data.dev_ds_password}}
-      url: jdbc:mysql://{{$orsp.Data.dev_ds_host}}/{{$orsp.Data.dev_ds_db}}?serverTimezone=UTC
+      url: jdbc:mariadb://{{$orsp.Data.dev_ds_host}}/{{$orsp.Data.dev_ds_db}}
       properties:
         initialSize: 5
         maxActive: 50
@@ -171,10 +171,10 @@ environments:
         statusUrl: http://bsp/BSP/
     dataSource:
       pooled: true
-      driverClassName: com.mysql.jdbc.Driver
+      driverClassName: org.mariadb.jdbc.Driver
       username: {{$orsp.Data.prod_ds_username}}
       password: {{$orsp.Data.prod_ds_password}}
-      url: jdbc:mysql://{{$orsp.Data.prod_ds_host}}/{{$orsp.Data.prod_ds_db}}?serverTimezone=UTC
+      url: jdbc:mariadb://{{$orsp.Data.prod_ds_host}}/{{$orsp.Data.prod_ds_db}}
       properties:
         jmxEnabled: true
         initialSize: 5


### PR DESCRIPTION
Addresses the license incompatibility between ORSP and MySQL Connector

SourceClear issue here (for consent, but same for ORSP): https://broadinstitute-dsp.sourceclear.io/teams/jppForw/issues/licenses/5391952/3352887