### PR TITLE
[BTRX-527][risk=no] Display Collection ID

### DIFF
--- a/grails-app/views/consentGroup/edit.gsp
+++ b/grails-app/views/consentGroup/edit.gsp
@@ -68,7 +68,7 @@
                     <tbody>
                     <g:each in="${collectionLinks}" var="link" status="index">
                         <tr>
-                            <td>${link.sampleCollection?.id}</td>
+                            <td>${link.sampleCollection?.collectionId}</td>
                             <td>${link.sampleCollection?.name}</td>
                             <td>${link.sampleCollection?.category}</td>
                             <td>${link.sampleCollection?.groupName}</td>

--- a/grails-app/views/consentGroup/show.gsp
+++ b/grails-app/views/consentGroup/show.gsp
@@ -187,7 +187,7 @@
                                         class="btn btn-default btn-sm">Remove</a>
                                 </td>
                             </auth:isOrsp>
-                            <td>${link.sampleCollection?.id}</td>
+                            <td>${link.sampleCollection?.collectionId}</td>
                             <td>${link.sampleCollection?.name}</td>
                             <td>${link.sampleCollection?.category}</td>
                             <td>${link.sampleCollection?.groupName}</td>


### PR DESCRIPTION
## Addresses
https://github.com/broadinstitute/orsp-pub/pull/new/BTRX-527

## Changes
Show the collection id instead of the database id.

---

- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Get a thumb from @rushtong
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
