### PR TITLE
[BTRX-523][risk=no] Use single list of attachment types across different projects

### DIFF
--- a/grails-app/controllers/org/broadinstitute/orsp/AuthenticatedController.groovy
+++ b/grails-app/controllers/org/broadinstitute/orsp/AuthenticatedController.groovy
@@ -18,7 +18,7 @@ class AuthenticatedController implements Interceptor, UserInfo {
     PersistenceService persistenceService
     StatusEventService statusEventService
 
-    public static final List<String> SUBMISSION_DOC_TYPES =
+    public static final List<String> PROJECT_DOC_TYPES =
             [ "Amendment Form",
               "Appendix",
               "Application",

--- a/grails-app/controllers/org/broadinstitute/orsp/ConsentGroupController.groovy
+++ b/grails-app/controllers/org/broadinstitute/orsp/ConsentGroupController.groovy
@@ -350,7 +350,7 @@ class ConsentGroupController extends AuthenticatedController {
         } catch (Exception e) {
             flash.error = "Unable to attach consent document: " + e.getMessage()
         }
-        redirect(controller: issue.controller, action: "show", params: [id: issue.projectKey, tab: "documents"])
+        redirect(controller: issue.controller, action: "show", params: [id: issue.projectKey, tab: "consent-groups"])
     }
 
 }

--- a/grails-app/controllers/org/broadinstitute/orsp/ConsentGroupController.groovy
+++ b/grails-app/controllers/org/broadinstitute/orsp/ConsentGroupController.groovy
@@ -8,17 +8,7 @@ import org.springframework.web.multipart.MultipartFile
  */
 class ConsentGroupController extends AuthenticatedController {
 
-    public static final String IC_LETTER = "Institutional Certification Letter"
     public static final String DU_LETTER = "Data Use Letter"
-    public static final String CONSENT_FORM = "Consent Form"
-    public static final String COLLAB_APPROVAL = "Collab. IRB approval"
-    public static final String MOU = "Memorandum of Understanding"
-    public static final String WAIVER = "Waiver of Consent"
-    public static final String ADDITIONAL_CONSENT_FORM = "Additional " + CONSENT_FORM
-    public static final String OTHER = "Other"
-
-    public static List<String> ATTACHMENT_TYPES = [CONSENT_FORM, COLLAB_APPROVAL, MOU, DU_LETTER, IC_LETTER, WAIVER]
-    public static List<String> ADDTL_ATTACHMENT_TYPES = [IC_LETTER, ADDITIONAL_CONSENT_FORM, OTHER]
 
     ConsentService consentService
 
@@ -193,9 +183,6 @@ class ConsentGroupController extends AuthenticatedController {
     show() {
         Issue issue = queryService.findByKey(params.id)
         def attachments = issue.attachments?.sort {a,b -> b.createDate <=> a.createDate}
-        def attachmentTypes = ATTACHMENT_TYPES - attachments?.collect { it.fileType }
-        def attachmentsPresent = attachmentTypes.isEmpty()
-        attachmentTypes += ADDTL_ATTACHMENT_TYPES
         def restriction = DataUseRestriction.findByConsentGroupKey(issue.projectKey)
         Collection<String> duSummary = consentService.getSummary(restriction)
         def collectionLinks = queryService.findCollectionLinksByConsentKey(issue.projectKey)
@@ -203,8 +190,7 @@ class ConsentGroupController extends AuthenticatedController {
         [issue: issue,
          collectionLinks: collectionLinks,
          attachments: attachments,
-         attachmentsPresent: attachmentsPresent,
-         attachmentTypes: attachmentTypes,
+         attachmentTypes: PROJECT_DOC_TYPES,
          restriction: restriction,
          duSummary: duSummary,
          tab: params.tab,
@@ -221,7 +207,9 @@ class ConsentGroupController extends AuthenticatedController {
                 view: "/consentGroup/list",
                 model: [
                         issue: issue,
-                        consentGroups: consentGroups?.sort {a, b -> a.summary?.toLowerCase() <=> b.summary?.toLowerCase()}
+                        consentGroups: consentGroups?.sort {a, b -> a.summary?.toLowerCase() <=> b.summary?.toLowerCase()},
+                        attachmentTypes: PROJECT_DOC_TYPES,
+                        controller: IssueType.CONSENT_GROUP.controller
                 ]
         )
     }
@@ -345,8 +333,7 @@ class ConsentGroupController extends AuthenticatedController {
                 model:
                         [issue: issue,
                          consent: consent,
-                         type: params.type
-                        ])
+                         attachmentTypes: PROJECT_DOC_TYPES])
     }
 
     def attachConsentDocument() {

--- a/grails-app/controllers/org/broadinstitute/orsp/IrbController.groovy
+++ b/grails-app/controllers/org/broadinstitute/orsp/IrbController.groovy
@@ -8,12 +8,6 @@ import org.springframework.web.multipart.MultipartFile
  */
 class IrbController extends AuthenticatedController {
 
-    public static final List<String> ATTACHMENT_DOC_TYPES =
-            ["Draft IRB Application",
-             "Final IRB Application",
-             "Broad's IRB approval",
-             "Other"]
-
     // TODO: Look into handling this better. The templates are tied to issue status and determine
     // which gsp template to show in a particular tab. I don't like handling this at the controller
     // level and would like to see this kind of view-specific logic moved closer to the view page.
@@ -65,9 +59,8 @@ class IrbController extends AuthenticatedController {
          workspaceTemplate : IRB_STATUS_TEMPLATES.get(issue?.status?.toLowerCase(), ""),
          extraProperties   : issue.getExtraProperties(),
          isProject         : true,
-         attachmentTypes   : ATTACHMENT_DOC_TYPES,
+         attachmentTypes   : PROJECT_DOC_TYPES,
          tab               : params.tab,
-         amendmentTypes    : SUBMISSION_DOC_TYPES,
          storageDocuments  : storageDocuments,
          groupedSubmissions: groupedSubmissions
         ]

--- a/grails-app/controllers/org/broadinstitute/orsp/NeController.groovy
+++ b/grails-app/controllers/org/broadinstitute/orsp/NeController.groovy
@@ -10,8 +10,6 @@ import org.springframework.web.multipart.MultipartFile
 @Slf4j
 class NeController extends AuthenticatedController {
 
-    public static List<String> ATTACHMENT_DOC_TYPES = ["Other"]
-
     public static final Map<String, String> NON_IRB_STATUS_TEMPLATES =
             ["submitting to orsp": "submit",
              "reviewing form": "review",
@@ -59,9 +57,8 @@ class NeController extends AuthenticatedController {
          workspaceTemplate : NON_IRB_STATUS_TEMPLATES.get(issue?.status?.toLowerCase(), ""),
          extraProperties   : issue.getExtraProperties(),
          attachments       : issue.attachments?.sort { a, b -> b.createDate <=> a.createDate },
-         attachmentTypes   : ATTACHMENT_DOC_TYPES,
+         attachmentTypes   : PROJECT_DOC_TYPES,
          tab               : params.tab,
-         amendmentTypes    : SUBMISSION_DOC_TYPES,
          storageDocuments  : storageDocuments,
          groupedSubmissions: groupedSubmissions
         ]

--- a/grails-app/controllers/org/broadinstitute/orsp/NhsrController.groovy
+++ b/grails-app/controllers/org/broadinstitute/orsp/NhsrController.groovy
@@ -36,9 +36,8 @@ class NhsrController extends NeController {
          workspaceTemplate : NON_IRB_STATUS_TEMPLATES.get(issue?.status?.toLowerCase(), ""),
          extraProperties   : issue.getExtraProperties(),
          attachments       : issue.attachments?.sort { a, b -> b.createDate <=> a.createDate },
-         attachmentTypes   : ATTACHMENT_DOC_TYPES,
+         attachmentTypes   : PROJECT_DOC_TYPES,
          tab               : params.tab,
-         amendmentTypes    : SUBMISSION_DOC_TYPES,
          storageDocuments  : storageDocuments,
          groupedSubmissions: groupedSubmissions
         ]

--- a/grails-app/controllers/org/broadinstitute/orsp/SubmissionController.groovy
+++ b/grails-app/controllers/org/broadinstitute/orsp/SubmissionController.groovy
@@ -32,7 +32,7 @@ class SubmissionController extends AuthenticatedController {
         render(view: '/submission/submission',
                 model: [issue:                      issue,
                         submission:                 submission,
-                        docTypes:                   SUBMISSION_DOC_TYPES,
+                        docTypes:                   PROJECT_DOC_TYPES,
                         submissionTypes:            submissionTypes,
                         submissionNumberMaximums:   submissionNumberMaximums,
                         defaultType:                defaultType
@@ -69,7 +69,7 @@ class SubmissionController extends AuthenticatedController {
                 model: [issue     : issue,
                         submission: submission,
                         minNumber : number,
-                        docTypes  : SUBMISSION_DOC_TYPES,
+                        docTypes  : PROJECT_DOC_TYPES,
                         submissionTypes: getSubmissionTypesForIssueType(issue.getType())])
     }
 
@@ -119,7 +119,7 @@ class SubmissionController extends AuthenticatedController {
                 model: [issue     : issue,
                         submission: submission,
                         minNumber : submission.number,
-                        docTypes  : SUBMISSION_DOC_TYPES,
+                        docTypes  : PROJECT_DOC_TYPES,
                         submissionTypes: getSubmissionTypesForIssueType(issue.getType())])
     }
 
@@ -143,7 +143,7 @@ class SubmissionController extends AuthenticatedController {
                 model: [issue     : issue,
                         submission: submission,
                         minNumber : submission.number,
-                        docTypes  : SUBMISSION_DOC_TYPES,
+                        docTypes  : PROJECT_DOC_TYPES,
                         submissionTypes: getSubmissionTypesForIssueType(issue.getType())])
     }
 

--- a/grails-app/domain/org/broadinstitute/orsp/Issue.groovy
+++ b/grails-app/domain/org/broadinstitute/orsp/Issue.groovy
@@ -37,20 +37,6 @@ class Issue {
 
     transient Boolean isLocked() { isFlagSet(IssueExtraProperty.LOCKED) }
 
-    transient nonProjAttachTypes() {
-        def existingFileTypes = [attachments*.fileType].flatten()
-        def options = (type == IssueType.CONSENT_GROUP.name) ? ConsentGroupController.ATTACHMENT_TYPES : []
-        if (options) {
-            options -= existingFileTypes
-        }
-        if (type == IssueType.CONSENT_GROUP.name) {
-            if (!options.contains(ConsentGroupController.IC_LETTER)) { options += ConsentGroupController.IC_LETTER }
-            options += ConsentGroupController.ADDTL_ATTACHMENT_TYPES
-        }
-        return options
-    }
-
-
     transient String getController() {
         IssueUtils.getControllerForIssueTypeName(type)
     }

--- a/grails-app/views/consentGroup/_attachConsentDocument.gsp
+++ b/grails-app/views/consentGroup/_attachConsentDocument.gsp
@@ -1,3 +1,13 @@
+%{--
+This template requires the following arguments:
+
+[
+    issue
+    consent
+    attachmentTypes
+]
+
+--}%
 <div class="modal-dialog modal-lg">
     <div class="modal-content">
         <g:form controller="consentGroup" action="attachConsentDocument" enctype="multipart/form-data" method="POST" class="attach-input">
@@ -11,8 +21,8 @@
                 <div class="form-group">
                     <label for="type">Type</label>
                     <select name="type" id="type" class="chosen-select form-control">
-                        <g:each in="${consent.nonProjAttachTypes()}" var="attachmentType">
-                            <option value="${attachmentType}" <g:if test="${type == attachmentType}">selected="selected"</g:if>>${attachmentType}</option>
+                        <g:each in="${attachmentTypes}" var="attachmentType">
+                            <option value="${attachmentType}">${attachmentType}</option>
                         </g:each>
                     </select>
                 </div>

--- a/grails-app/views/consentGroup/list.gsp
+++ b/grails-app/views/consentGroup/list.gsp
@@ -46,24 +46,6 @@
                         </thead>
                         <tbody>
 
-                        <g:each in="${consent.nonProjAttachTypes()}" var="type" status="index">
-                            <tr>
-                                <td>
-                                    <button
-                                            class="btn btn-default btn-xs modal-add-button"
-                                            data-issue="${issue.projectKey}"
-                                            data-consent="${consent.projectKey}"
-                                            data-type="${type}">
-                                        Add
-                                    </button>
-                                </td>
-                                <td>${type}</td>
-                                <td></td>
-                                <td></td>
-                                <td></td>
-                            </tr>
-                        </g:each>
-
                         <g:each in="${consent.attachments?.sort {a,b -> b.createDate <=> a.createDate}}" var="document">
                             <tr>
                                 <td>
@@ -87,6 +69,23 @@
                         </g:each>
 
                         </tbody>
+
+                        <tfoot>
+                        <tr class="text-right">
+                            <td colspan="5">
+                                <g:if test="${!issue.isLocked() || session?.isOrsp}">
+                                    <button class="btn btn-default btn-sm modal-add-button"
+                                            data-toggle="modal"
+                                            data-issue="${issue.projectKey}"
+                                            data-consent="${consent.projectKey}"
+                                            data-target="#upload-attachment">Add Consent Attachment</button>
+                                </g:if>
+                                <g:else>
+                                    <button disabled="disabled" class="btn btn-default btn-sm">Add Attachment</button>
+                                </g:else>
+                            </td>
+                        </tr>
+                        </tfoot>
                     </table>
                 </div>
             </div>

--- a/grails-app/views/irb/show.gsp
+++ b/grails-app/views/irb/show.gsp
@@ -161,7 +161,6 @@
                                 {
                                     issueKey: $(this).data("issue"),
                                     consentKey: $(this).data("consent"),
-                                    type: $(this).data("type"),
                                     controller: "${issue.controller}"
                                 },
                                 function() {

--- a/grails-app/views/layouts/_footer.gsp
+++ b/grails-app/views/layouts/_footer.gsp
@@ -37,7 +37,7 @@
 <asset:javascript src="jquery.fn.dataTablesExt.ticket.js"/>
 <asset:javascript src="chosen.jquery.min.js"/>
 <asset:javascript src="jasny-bootstrap.min.js"/>
-<script src="https://cloud.tinymce.com/stable/tinymce.min.js?apiKey=8zknubfnjvv9l3sg0cpxrome1qk6r2wlpdw7j4ebb3gjxige"></script>
+<script src="https://cloud.tinymce.com/5/tinymce.min.js?apiKey=8zknubfnjvv9l3sg0cpxrome1qk6r2wlpdw7j4ebb3gjxige"></script>
 <asset:javascript src="jquery.validate.min.js"/>
 <asset:javascript src="jsrender.js"/>
 

--- a/grails-app/views/ne/show.gsp
+++ b/grails-app/views/ne/show.gsp
@@ -156,7 +156,6 @@
                                 {
                                     issueKey: $(this).data("issue"),
                                     consentKey: $(this).data("consent"),
-                                    type: $(this).data("type"),
                                     controller: "${issue.controller}"
                                 },
                                 function() {

--- a/grails-app/views/nhsr/show.gsp
+++ b/grails-app/views/nhsr/show.gsp
@@ -158,7 +158,6 @@
                                 {
                                     issueKey: $(this).data("issue"),
                                     consentKey: $(this).data("consent"),
-                                    type: $(this).data("type"),
                                     controller: "${issue.controller}"
                                 },
                                 function() {

--- a/src/main/groovy/org/broadinstitute/orsp/SubmissionType.groovy
+++ b/src/main/groovy/org/broadinstitute/orsp/SubmissionType.groovy
@@ -10,6 +10,10 @@ enum SubmissionType {
     String label
     Collection<IssueType> issueTypes
 
+    /**
+     * @param label Label string
+     * @param issueTypes Collection of issue types for which the submission type is applicable
+     */
     SubmissionType(String label, Collection<IssueType> issueTypes) {
         this.label = label
         this.issueTypes = issueTypes

--- a/src/main/groovy/org/broadinstitute/orsp/SubmissionType.groovy
+++ b/src/main/groovy/org/broadinstitute/orsp/SubmissionType.groovy
@@ -2,8 +2,8 @@ package org.broadinstitute.orsp;
 
 enum SubmissionType {
 
-    ContinuingReview ("Continuing Review", [IssueType.IRB]),
     Amendment ("Amendment", [IssueType.IRB, IssueType.NE, IssueType.NHSR]),
+    ContinuingReview ("Continuing Review", [IssueType.IRB]),
     OtherEvent ("Other Event", [IssueType.IRB]),
     Other ("Other", [IssueType.IRB, IssueType.NE, IssueType.NHSR])
 


### PR DESCRIPTION
## Addresses
Partly addresses https://broadinstitute.atlassian.net/browse/BTRX-523
This PR targets `master` which is current production. `feature` has a very different document flow so I will address that aspect in a separate PR, these branches have diverged a lot in the interim. 

## Changes
* Use one list of attachment types across all projects
* Update view of consent attachments inside of a project
* Don't restrict document uploads by type
* After uploading a consent group doc from inside of a project, redirect back to the consent group tab. It was redirecting to the documents tab.
* Order Amendments first under the submissions tab
* Upgrade [tinymce lib to v5](https://go.tiny.cloud/blog/tinymce-5-is-now-in-the-cloud/)

## Consent Group Screens inside a Project
New consent document view from inside a project:
<img width="1154" alt="screen shot 2019-02-06 at 10 14 38 am" src="https://user-images.githubusercontent.com/116679/52351289-7a2e6580-29f8-11e9-8b05-2e9311dc6188.png">

New view of adding a consent group document from inside of a project:
<img width="1163" alt="screen shot 2019-02-06 at 10 14 25 am" src="https://user-images.githubusercontent.com/116679/52351338-8e726280-29f8-11e9-8066-cca178555799.png">

## Document Upload View
The list of new attachment types is available for any document added to a project:
<img width="1178" alt="screen shot 2019-02-06 at 10 18 53 am" src="https://user-images.githubusercontent.com/116679/52351542-fc1e8e80-29f8-11e9-8cae-a513c8acf74f.png">

---

- [x] **Submitter**: Verify all tests go green, including CI tests
- [x] **Submitter**: Get a thumb from @rushtong
- [x] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
