### PR TITLE
Auth command deprecated, use login instead

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -47,5 +47,5 @@ Execution failed for task ':renderConfigs'.
 ```
 Authenticate (or see dsde-toolbox link for authenticating)
 ```
-vault auth -method=github token=$(cat ~/.github-token)
+vault login -method=github token=$(cat ~/.github-token)
 ```


### PR DESCRIPTION
No story. with the latest update to `vault`, the `auth` command is deprecated. 