### PR TITLE
BTRX-593 ORSP - New Project Generation Workflow Button Updates

### DIFF
--- a/src/main/webapp/components/QuestionnaireWorkflow.js
+++ b/src/main/webapp/components/QuestionnaireWorkflow.js
@@ -205,12 +205,8 @@ export const QuestionnaireWorkflow = hh(class QuestionnaireWorkflow extends Comp
         small({ isRendered: this.state.requiredError === true, className: "errorMessage" }, ["Required field"]),
 
         div({ className: "buttonContainer" }, [
-          button({ isRendered: (currentQuestionIndex > 0), className: "btn buttonSecondary circleBtn floatLeft", onClick: this.prevQuestion }, [
-            span({ className: "glyphicon glyphicon-chevron-left" }, [])
-          ]),
-          button({ isRendered: (this.state.endState === false), className: "btn buttonPrimary circleBtn floatRight", onClick: this.nextQuestion }, [
-            span({ className: "glyphicon glyphicon-chevron-right" }, [])
-          ])
+          button({ isRendered: (currentQuestionIndex > 0), className: "btn buttonSecondary floatLeft", onClick: this.prevQuestion }, ["Previous Question"]),
+          button({ isRendered: (this.state.endState === false), className: "btn buttonPrimary floatRight", onClick: this.nextQuestion }, ["Next Question"])
         ])
       ])
     )

--- a/src/main/webapp/project/NewProjectDetermination.js
+++ b/src/main/webapp/project/NewProjectDetermination.js
@@ -125,7 +125,7 @@ export const NewProjectDetermination = hh(class NewProjectDetermination extends 
 
     return (
       WizardStep({ title: this.props.title, step: 1, currentStep: this.props.currentStep, questionnaireStep: true,
-                   error: this.props.errors, errorMessage: ' Please answer all questions to continue'}, [
+                   error: this.props.errors, errorMessage: 'Please answer the next question(s) above before moving to the next step'}, [
         QuestionnaireWorkflow({ questions: this.state.questions, determination: this.props.determination, handler: this.props.handler })
       ])
     )


### PR DESCRIPTION
## Addresses
Current State:
The button to proceed to the next question is a circle with an arrow. Users often instead look directly to the rectangular 'Next Step' button below and click it to proceed, thinking they are doing so correctly but are confused when they cannot proceed.
Future State: 
Change the circular arrow button to say "Next Question" and choose the most appropriate button style/shape. Please also update the red help text which appears when the 'Next Step' button is clicked prior to 100% of answers being provided to say "Please answer the next question(s) above before moving to the next step"

Options
## Changes

## Testing

---

- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Get a thumb from @rushtong
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
