### PR TITLE
[BTRX-523][risk=no] Use single list of attachment types across different projects (#57)

### DIFF
--- a/grails-app/controllers/org/broadinstitute/orsp/AuthenticatedController.groovy
+++ b/grails-app/controllers/org/broadinstitute/orsp/AuthenticatedController.groovy
@@ -19,7 +19,7 @@ class AuthenticatedController implements Interceptor, UserInfo {
     StatusEventService statusEventService
     PermissionService permissionService
 
-    public static final List<String> SUBMISSION_DOC_TYPES =
+    public static final List<String> PROJECT_DOC_TYPES =
             [ "Amendment Form",
               "Appendix",
               "Application",

--- a/grails-app/controllers/org/broadinstitute/orsp/ConsentGroupController.groovy
+++ b/grails-app/controllers/org/broadinstitute/orsp/ConsentGroupController.groovy
@@ -8,17 +8,7 @@ import org.springframework.web.multipart.MultipartFile
  */
 class ConsentGroupController extends AuthenticatedController {
 
-    public static final String IC_LETTER = "Institutional Certification Letter"
     public static final String DU_LETTER = "Data Use Letter"
-    public static final String CONSENT_FORM = "Consent Form"
-    public static final String COLLAB_APPROVAL = "Collab. IRB approval"
-    public static final String MOU = "Memorandum of Understanding"
-    public static final String WAIVER = "Waiver of Consent"
-    public static final String ADDITIONAL_CONSENT_FORM = "Additional " + CONSENT_FORM
-    public static final String OTHER = "Other"
-
-    public static List<String> ATTACHMENT_TYPES = [CONSENT_FORM, COLLAB_APPROVAL, MOU, DU_LETTER, IC_LETTER, WAIVER]
-    public static List<String> ADDTL_ATTACHMENT_TYPES = [IC_LETTER, ADDITIONAL_CONSENT_FORM, OTHER]
 
     ConsentService consentService
 
@@ -196,9 +186,6 @@ class ConsentGroupController extends AuthenticatedController {
             redirect(controller: 'Index', action: 'index')
         }
         def attachments = issue.attachments?.sort {a,b -> b.createDate <=> a.createDate}
-        def attachmentTypes = ATTACHMENT_TYPES - attachments?.collect { it.fileType }
-        def attachmentsPresent = attachmentTypes.isEmpty()
-        attachmentTypes += ADDTL_ATTACHMENT_TYPES
         def restriction = DataUseRestriction.findByConsentGroupKey(issue.projectKey)
         Collection<String> duSummary = consentService.getSummary(restriction)
         def collectionLinks = queryService.findCollectionLinksByConsentKey(issue.projectKey)
@@ -206,8 +193,7 @@ class ConsentGroupController extends AuthenticatedController {
         [issue: issue,
          collectionLinks: collectionLinks,
          attachments: attachments,
-         attachmentsPresent: attachmentsPresent,
-         attachmentTypes: attachmentTypes,
+         attachmentTypes: PROJECT_DOC_TYPES,
          restriction: restriction,
          duSummary: duSummary,
          tab: params.tab,
@@ -224,7 +210,9 @@ class ConsentGroupController extends AuthenticatedController {
                 view: "/consentGroup/list",
                 model: [
                         issue: issue,
-                        consentGroups: consentGroups?.sort {a, b -> a.summary?.toLowerCase() <=> b.summary?.toLowerCase()}
+                        consentGroups: consentGroups?.sort {a, b -> a.summary?.toLowerCase() <=> b.summary?.toLowerCase()},
+                        attachmentTypes: PROJECT_DOC_TYPES,
+                        controller: IssueType.CONSENT_GROUP.controller
                 ]
         )
     }
@@ -354,8 +342,7 @@ class ConsentGroupController extends AuthenticatedController {
                 model:
                         [issue: issue,
                          consent: consent,
-                         type: params.type
-                        ])
+                         attachmentTypes: PROJECT_DOC_TYPES])
     }
 
     def attachConsentDocument() {
@@ -372,7 +359,7 @@ class ConsentGroupController extends AuthenticatedController {
         } catch (Exception e) {
             flash.error = "Unable to attach consent document: " + e.getMessage()
         }
-        redirect(controller: issue.controller, action: "show", params: [id: issue.projectKey, tab: "documents"])
+        redirect(controller: issue.controller, action: "show", params: [id: issue.projectKey, tab: "consent-groups"])
     }
 
 }

--- a/grails-app/controllers/org/broadinstitute/orsp/IrbController.groovy
+++ b/grails-app/controllers/org/broadinstitute/orsp/IrbController.groovy
@@ -8,12 +8,6 @@ import org.springframework.web.multipart.MultipartFile
  */
 class IrbController extends AuthenticatedController {
 
-    public static final List<String> ATTACHMENT_DOC_TYPES =
-            ["Draft IRB Application",
-             "Final IRB Application",
-             "Broad's IRB approval",
-             "Other"]
-
     // TODO: Look into handling this better. The templates are tied to issue status and determine
     // which gsp template to show in a particular tab. I don't like handling this at the controller
     // level and would like to see this kind of view-specific logic moved closer to the view page.
@@ -69,9 +63,8 @@ class IrbController extends AuthenticatedController {
          workspaceTemplate : IRB_STATUS_TEMPLATES.get(issue?.status?.toLowerCase(), ""),
          extraProperties   : issue.getExtraProperties(),
          isProject         : true,
-         attachmentTypes   : ATTACHMENT_DOC_TYPES,
+         attachmentTypes   : PROJECT_DOC_TYPES,
          tab               : params.tab,
-         amendmentTypes    : SUBMISSION_DOC_TYPES,
          storageDocuments  : storageDocuments,
          groupedSubmissions: groupedSubmissions
         ]

--- a/grails-app/controllers/org/broadinstitute/orsp/NeController.groovy
+++ b/grails-app/controllers/org/broadinstitute/orsp/NeController.groovy
@@ -10,8 +10,6 @@ import org.springframework.web.multipart.MultipartFile
 @Slf4j
 class NeController extends AuthenticatedController {
 
-    public static List<String> ATTACHMENT_DOC_TYPES = ["Other"]
-
     public static final Map<String, String> NON_IRB_STATUS_TEMPLATES =
             ["submitting to orsp": "submit",
              "reviewing form": "review",
@@ -62,9 +60,8 @@ class NeController extends AuthenticatedController {
          workspaceTemplate : NON_IRB_STATUS_TEMPLATES.get(issue?.status?.toLowerCase(), ""),
          extraProperties   : issue.getExtraProperties(),
          attachments       : issue.attachments?.sort { a, b -> b.createDate <=> a.createDate },
-         attachmentTypes   : ATTACHMENT_DOC_TYPES,
+         attachmentTypes   : PROJECT_DOC_TYPES,
          tab               : params.tab,
-         amendmentTypes    : SUBMISSION_DOC_TYPES,
          storageDocuments  : storageDocuments,
          groupedSubmissions: groupedSubmissions
         ]

--- a/grails-app/controllers/org/broadinstitute/orsp/NhsrController.groovy
+++ b/grails-app/controllers/org/broadinstitute/orsp/NhsrController.groovy
@@ -39,9 +39,8 @@ class NhsrController extends NeController {
          workspaceTemplate : NON_IRB_STATUS_TEMPLATES.get(issue?.status?.toLowerCase(), ""),
          extraProperties   : issue.getExtraProperties(),
          attachments       : issue.attachments?.sort { a, b -> b.createDate <=> a.createDate },
-         attachmentTypes   : ATTACHMENT_DOC_TYPES,
+         attachmentTypes   : PROJECT_DOC_TYPES,
          tab               : params.tab,
-         amendmentTypes    : SUBMISSION_DOC_TYPES,
          storageDocuments  : storageDocuments,
          groupedSubmissions: groupedSubmissions
         ]

--- a/grails-app/controllers/org/broadinstitute/orsp/SubmissionController.groovy
+++ b/grails-app/controllers/org/broadinstitute/orsp/SubmissionController.groovy
@@ -32,7 +32,7 @@ class SubmissionController extends AuthenticatedController {
         render(view: '/submission/submission',
                 model: [issue:                      issue,
                         submission:                 submission,
-                        docTypes:                   SUBMISSION_DOC_TYPES,
+                        docTypes:                   PROJECT_DOC_TYPES,
                         submissionTypes:            submissionTypes,
                         submissionNumberMaximums:   submissionNumberMaximums,
                         defaultType:                defaultType
@@ -69,7 +69,7 @@ class SubmissionController extends AuthenticatedController {
                 model: [issue     : issue,
                         submission: submission,
                         minNumber : number,
-                        docTypes  : SUBMISSION_DOC_TYPES,
+                        docTypes  : PROJECT_DOC_TYPES,
                         submissionTypes: getSubmissionTypesForIssueType(issue.getType())])
     }
 
@@ -119,7 +119,7 @@ class SubmissionController extends AuthenticatedController {
                 model: [issue     : issue,
                         submission: submission,
                         minNumber : submission.number,
-                        docTypes  : SUBMISSION_DOC_TYPES,
+                        docTypes  : PROJECT_DOC_TYPES,
                         submissionTypes: getSubmissionTypesForIssueType(issue.getType())])
     }
 
@@ -143,7 +143,7 @@ class SubmissionController extends AuthenticatedController {
                 model: [issue     : issue,
                         submission: submission,
                         minNumber : submission.number,
-                        docTypes  : SUBMISSION_DOC_TYPES,
+                        docTypes  : PROJECT_DOC_TYPES,
                         submissionTypes: getSubmissionTypesForIssueType(issue.getType())])
     }
 

--- a/grails-app/domain/org/broadinstitute/orsp/Issue.groovy
+++ b/grails-app/domain/org/broadinstitute/orsp/Issue.groovy
@@ -44,22 +44,6 @@ class Issue implements LogicalDelete<Issue> {
 
     transient Boolean isLocked() { isFlagSet(IssueExtraProperty.LOCKED) }
 
-    transient nonProjAttachTypes() {
-        def existingFileTypes = [attachments*.fileType].flatten()
-        def options = (type == IssueType.CONSENT_GROUP.name) ? ConsentGroupController.ATTACHMENT_TYPES : []
-        if (options) {
-            options -= existingFileTypes
-        }
-        if (type == IssueType.CONSENT_GROUP.name) {
-            if (!options.contains(ConsentGroupController.IC_LETTER)) {
-                options += ConsentGroupController.IC_LETTER
-            }
-            options += ConsentGroupController.ADDTL_ATTACHMENT_TYPES
-        }
-        return options
-    }
-
-
     transient String getController() {
         IssueUtils.getControllerForIssueTypeName(type)
     }

--- a/grails-app/services/org/broadinstitute/orsp/IssueService.groovy
+++ b/grails-app/services/org/broadinstitute/orsp/IssueService.groovy
@@ -3,7 +3,6 @@ package org.broadinstitute.orsp
 import grails.gorm.transactions.Transactional
 import grails.web.servlet.mvc.GrailsParameterMap
 import groovy.util.logging.Slf4j
-import org.broadinstitute.orsp.ConsentCollectionLink
 
 /**
  * This class handles the general update or creation of issues and nothing more.

--- a/grails-app/views/consentGroup/_attachConsentDocument.gsp
+++ b/grails-app/views/consentGroup/_attachConsentDocument.gsp
@@ -1,3 +1,13 @@
+%{--
+This template requires the following arguments:
+
+[
+    issue
+    consent
+    attachmentTypes
+]
+
+--}%
 <div class="modal-dialog modal-lg">
     <div class="modal-content">
         <g:form controller="consentGroup" action="attachConsentDocument" enctype="multipart/form-data" method="POST" class="attach-input">
@@ -11,8 +21,8 @@
                 <div class="form-group">
                     <label for="type">Type</label>
                     <select name="type" id="type" class="chosen-select form-control">
-                        <g:each in="${consent.nonProjAttachTypes()}" var="attachmentType">
-                            <option value="${attachmentType}" <g:if test="${type == attachmentType}">selected="selected"</g:if>>${attachmentType}</option>
+                        <g:each in="${attachmentTypes}" var="attachmentType">
+                            <option value="${attachmentType}">${attachmentType}</option>
                         </g:each>
                     </select>
                 </div>

--- a/grails-app/views/consentGroup/list.gsp
+++ b/grails-app/views/consentGroup/list.gsp
@@ -47,24 +47,6 @@
                         </thead>
                         <tbody>
 
-                        <g:each in="${consent.nonProjAttachTypes()}" var="type" status="index">
-                            <tr>
-                                <td>
-                                    <button
-                                            class="btn btn-default btn-xs modal-add-button"
-                                            data-issue="${issue.projectKey}"
-                                            data-consent="${consent.projectKey}"
-                                            data-type="${type}">
-                                        Add
-                                    </button>
-                                </td>
-                                <td>${type}</td>
-                                <td></td>
-                                <td></td>
-                                <td></td>
-                            </tr>
-                        </g:each>
-
                         <g:each in="${consent.attachments?.sort {a,b -> b.createDate <=> a.createDate}}" var="document">
                             <tr>
                                 <td>
@@ -88,6 +70,23 @@
                         </g:each>
 
                         </tbody>
+
+                        <tfoot>
+                        <tr class="text-right">
+                            <td colspan="5">
+                                <g:if test="${!issue.isLocked() || session?.isOrsp}">
+                                    <button class="btn btn-default btn-sm modal-add-button"
+                                            data-toggle="modal"
+                                            data-issue="${issue.projectKey}"
+                                            data-consent="${consent.projectKey}"
+                                            data-target="#upload-attachment">Add Consent Attachment</button>
+                                </g:if>
+                                <g:else>
+                                    <button disabled="disabled" class="btn btn-default btn-sm">Add Attachment</button>
+                                </g:else>
+                            </td>
+                        </tr>
+                        </tfoot>
                     </table>
                 </div>
             </div>

--- a/grails-app/views/irb/show.gsp
+++ b/grails-app/views/irb/show.gsp
@@ -179,7 +179,6 @@
                                 {
                                     issueKey: $(this).data("issue"),
                                     consentKey: $(this).data("consent"),
-                                    type: $(this).data("type"),
                                     controller: "${issue.controller}"
                                 },
                                 function() {

--- a/grails-app/views/layouts/_footer.gsp
+++ b/grails-app/views/layouts/_footer.gsp
@@ -37,7 +37,7 @@
 <asset:javascript src="jquery.fn.dataTablesExt.ticket.js"/>
 <asset:javascript src="chosen.jquery.min.js"/>
 <asset:javascript src="jasny-bootstrap.min.js"/>
-<script src="https://cloud.tinymce.com/stable/tinymce.min.js?apiKey=8zknubfnjvv9l3sg0cpxrome1qk6r2wlpdw7j4ebb3gjxige"></script>
+<script src="https://cloud.tinymce.com/5/tinymce.min.js?apiKey=8zknubfnjvv9l3sg0cpxrome1qk6r2wlpdw7j4ebb3gjxige"></script>
 <asset:javascript src="jquery.validate.min.js"/>
 <asset:javascript src="jsrender.js"/>
 

--- a/grails-app/views/ne/show.gsp
+++ b/grails-app/views/ne/show.gsp
@@ -174,7 +174,6 @@
                                 {
                                     issueKey: $(this).data("issue"),
                                     consentKey: $(this).data("consent"),
-                                    type: $(this).data("type"),
                                     controller: "${issue.controller}"
                                 },
                                 function() {

--- a/grails-app/views/nhsr/show.gsp
+++ b/grails-app/views/nhsr/show.gsp
@@ -177,7 +177,6 @@
                                 {
                                     issueKey: $(this).data("issue"),
                                     consentKey: $(this).data("consent"),
-                                    type: $(this).data("type"),
                                     controller: "${issue.controller}"
                                 },
                                 function() {

--- a/src/main/groovy/org/broadinstitute/orsp/SubmissionType.groovy
+++ b/src/main/groovy/org/broadinstitute/orsp/SubmissionType.groovy
@@ -2,14 +2,18 @@ package org.broadinstitute.orsp;
 
 enum SubmissionType {
 
-    ContinuingReview ("Continuing Review", [IssueType.IRB]),
     Amendment ("Amendment", [IssueType.IRB, IssueType.NE, IssueType.NHSR]),
+    ContinuingReview ("Continuing Review", [IssueType.IRB]),
     OtherEvent ("Other Event", [IssueType.IRB]),
     Other ("Other", [IssueType.IRB, IssueType.NE, IssueType.NHSR])
 
     String label
     Collection<IssueType> issueTypes
 
+    /**
+     * @param label Label string
+     * @param issueTypes Collection of issue types for which the submission type is applicable
+     */
     SubmissionType(String label, Collection<IssueType> issueTypes) {
         this.label = label
         this.issueTypes = issueTypes


### PR DESCRIPTION
## Addresses
Addresses https://broadinstitute.atlassian.net/browse/BTRX-523
Copy of https://github.com/broadinstitute/orsp-pub/pull/57 against the `feature` branch

## Changes
See https://github.com/broadinstitute/orsp-pub/pull/57

---

- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Get a thumb from @rushtong
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
