### PR TITLE
Refactor the react index.gsp files

### DIFF
--- a/grails-app/views/dataUseLetter/index.gsp
+++ b/grails-app/views/dataUseLetter/index.gsp
@@ -1,22 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="layout" content="main"/>
-    <meta charset="utf-8"/>
-
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.20.1/moment-with-locales.min.js"></script>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/react-bootstrap-table/4.3.1/react-bootstrap-table-all.min.css"/>
-    <link rel="stylesheet" href="https://unpkg.com/react-bootstrap-typeahead/css/Typeahead.css"/>
+    <meta name="layout" content="main_component"/>
     <title>Data Use Letter</title>
-
-    <script type="application/javascript">
-    const dataUseLetterComponent = {
-        serverURL: "${webRequest.baseUrl}",
-        consentGroupUrl: "${createLink(controller: 'newConsentGroup', action: 'findByUUID')}",
-        error: "${error}",
-        loadingImage: "${resource(dir: 'images', file: 'loading-indicator.svg')}"
-    };
-    </script>
 </head>
 <body>
 

--- a/grails-app/views/layouts/main_component.gsp
+++ b/grails-app/views/layouts/main_component.gsp
@@ -1,0 +1,184 @@
+<%@ page import="org.broadinstitute.orsp.IssueStatus" %>
+<%@ page import="org.broadinstitute.orsp.IssueType" %>
+<%@ page import="org.broadinstitute.orsp.PreferredIrb" %>
+
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge">
+    <title><g:layoutTitle default="ORSP Portal"/></title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="ORSP Portal">
+    <meta name="author" content="ORSP">
+    <meta name="google-signin-client_id" content="${grailsApplication.config.googleSignInClientId}">
+    <meta charset="utf-8"/>
+
+    <link rel="shortcut icon" href="${resource(dir: 'assets', file: 'favicon.ico')}" type="image/x-icon">
+    <link rel="apple-touch-icon" href="${resource(dir: 'assets', file: 'apple-touch-icon.png')}">
+    <link rel="apple-touch-icon" sizes="114x114" href="${resource(dir: 'images', file: 'apple-touch-icon-retina.png')}">
+    <link rel="stylesheet" href="//code.jquery.com/ui/1.11.2/themes/smoothness/jquery-ui.css" />
+    <asset:stylesheet src="chosen/chosen.css"/>
+    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css">
+    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css">
+    <asset:stylesheet src="bootstrap-customizations.css"/>
+    <asset:stylesheet src="jasny-bootstrap.min.css"/>
+    <link rel="stylesheet" href="//cdn.datatables.net/1.10.4/css/jquery.dataTables.min.css">
+    <link rel="stylesheet" href="//cdn.datatables.net/tabletools/2.2.3/css/dataTables.tableTools.css">
+    %{-- We need this custom table tools css file to override display issues with cdn version --}%
+
+    <asset:stylesheet src="jquery.dataTables.css"/>
+    <asset:stylesheet src="style.css"/>
+    <style type="text/css" title="TableTools">
+    @import "${request.contextPath}/assets/media/css/TableTools.css";
+    .ui-autocomplete-loading {
+        background: white url('${request.contextPath}/assets/spinner.gif') right center no-repeat;
+    }
+    @media (min-width: 765px) and (max-width: 1200px) {
+        body {
+            margin-top: 110px;
+        }
+    }
+    </style>
+    <script src="https://apis.google.com/js/platform.js" async defer></script>
+
+    <script>
+        if (location.protocol !== "https:") location.protocol = "https:";
+        function onSignIn(googleUser) {
+            // show spinner while the page is re-loading
+            document.getElementById("login_spinner").setAttribute("class", "visible");
+            var profile = googleUser.getBasicProfile();
+            var token = googleUser.getAuthResponse().id_token;
+            var auth2 = gapi.auth2.getAuthInstance();
+            auth2.then(function() {
+                var xhttp = new XMLHttpRequest();
+
+                %{--
+                    This is here so that after a Broad user signs in, their page is refreshed with valid content
+                    Overwrites previous onreadystatechange
+                --}%
+                <auth:isNotAuthenticated>
+                xhttp.onreadystatechange = function() {
+                    if (this.readyState == 4 && this.status == 200) {
+                        location.reload();
+                    }
+                };
+                </auth:isNotAuthenticated>
+                var url = "${raw(createLink(controller: "auth", action: "authUser"))}";
+                var postData = "token=" + token;
+                xhttp.open("POST", url, true);
+                xhttp.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
+                xhttp.send(postData);
+            });
+        }
+        function signOut() {
+            var auth2 = gapi.auth2.getAuthInstance();
+            auth2.signOut().then(function (){
+                var xhttp = new XMLHttpRequest();
+                xhttp.onreadystatechange = function() {
+                    if (this.readyState == 4 && this.status == 200) {
+                        window.location = "${request.contextPath}";
+                    }
+                };
+                var url = "${raw(createLink(controller: "logout", action: "logout"))}";
+                xhttp.open("POST", url, true);
+                xhttp.send();
+            });
+        }
+    </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.20.1/moment-with-locales.min.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/react-bootstrap-table/4.3.1/react-bootstrap-table-all.min.css"/>
+    <link rel="stylesheet" href="https://unpkg.com/react-bootstrap-typeahead/css/Typeahead.css"/>
+
+     %{--
+        Add all component based code here.
+        TODO: These constants should all be refactored into a static utility class
+     --}%
+    <script type="application/javascript">
+      const issueTypes = [
+        <g:each status="count" in="${IssueType.values()}" var="type">"${raw(type.name)}"<g:if test="${count < IssueType.values().size() - 1}">,</g:if>
+        </g:each>];
+
+      const issueStatuses = [
+        <g:each status="count" in="${IssueStatus.values().sort{it.sequence}}" var="status">"${raw(status.name)}"<g:if test="${count < IssueStatus.values().size() - 1}">,</g:if>
+        </g:each>];
+
+      const irbs = [
+          <g:each status="count" in="${PreferredIrb.values()}" var="map">{ id:"${raw(map.key)}", value:"${raw(map.label)}"}<g:if test="${count < PreferredIrb.values().size() - 1}">,</g:if>
+        </g:each>];
+
+      // dataUseLetter TODO: Make the data use letter component use `component` instead.
+      const dataUseLetterComponent = {
+        serverURL: "${webRequest.baseUrl}",
+        consentGroupUrl: "${createLink(controller: 'newConsentGroup', action: 'findByUUID')}",
+        error: "${error}",
+        loadingImage: "${resource(dir: 'images', file: 'loading-indicator.svg')}"
+      };
+
+      // newConsentGroup, newProject, search
+      const component = {
+        searchUrl: "${createLink(controller: 'search', action: 'generalReactTablesJsonSearch')}",
+        getUserUrl: "${createLink(controller: 'authenticated', action: 'getSessionUser')}",
+        searchUsersURL: "${createLink(controller: 'search', action: 'getMatchingUsers')}",
+        sampleSearchUrl: "${createLink(controller: 'consentGroup', action: 'unConsentedSampleCollections')}",
+        consentNamesSearchURL: "${createLink(controller: 'consentGroup', action: 'consentGroupSummaries')}",
+        createConsentGroupURL: "${createLink(controller:'newConsentGroup', action: 'save', uri: '/api/consent-group', method: 'POST')}",
+        attachDocumentsURL: "${createLink(uri: '/api/files-helper/attach-document', method: 'POST')}",
+        serverURL: "${webRequest.baseUrl}",
+        fillablePdfURL : "${createLink(controller: 'newConsentGroup', action: 'downloadFillablePDF', method: 'GET')}",
+        projectKey: "${params.projectKey}",
+        loadingImage: "${resource(dir: 'images', file: 'loading-indicator.svg')}",
+        projectType: '${params.type}',
+        createProjectURL: "${createLink(controller:'project', action: 'save', uri: '/api/project', method: 'POST')}",
+        projectKeySearchUrl: "${createLink(controller: 'search', action: 'projectKeyAutocomplete')}",
+        userNameSearchUrl: "${createLink(controller: 'search', action: 'getMatchingUsers')}",
+        issueTypes: issueTypes,
+        issueStatuses: issueStatuses,
+        irbs: irbs
+      };
+    </script>
+
+    <g:layoutHead/>
+</head>
+<body>
+<g:render template="/base/topNav" />
+
+<auth:isNotAuthenticated>
+    <div class="container">
+        <div id="login_spinner" class="hidden">
+            <div class="alert alert-success alert-dismissable" style="display: block">
+                Loading ... <span class="glyphicon glyphicon-refresh glyphicon-refresh-animate"></span>
+            </div>
+        </div>
+        <h3>About the ORSP Portal</h3>
+        <g:render template="/index/aboutBlurb"/>
+    </div>
+</auth:isNotAuthenticated>
+
+<auth:nonBroadSession>
+    <div class="container">
+        <div class="alert alert-danger alert-dismissable" style="display: block">
+            You must be a Broad Institute User for further access. Please sign out and log in with
+            a "broadinstitute.org" email account.
+        </div>
+        <h3>About the ORSP Portal</h3>
+        <g:render template="/index/aboutBlurb"/>
+    </div>
+</auth:nonBroadSession>
+
+<auth:broadSession>
+    <div class="container">
+        <g:render template="/base/messages" />
+        <g:layoutBody/>
+    </div>
+</auth:broadSession>
+
+<div id="footer">
+    <div class="container">
+        <g:render template="/layouts/footer" />
+    </div>
+</div>
+
+<asset:deferredScripts/>
+</body>
+</html>

--- a/grails-app/views/newConsentGroup/index.gsp
+++ b/grails-app/views/newConsentGroup/index.gsp
@@ -1,29 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="layout" content="main">
-    <meta charset="utf-8"/>
-
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.20.1/moment-with-locales.min.js"></script>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/react-bootstrap-table/4.3.1/react-bootstrap-table-all.min.css"/>
-    <link rel="stylesheet" href="https://unpkg.com/react-bootstrap-typeahead/css/Typeahead.css">
+    <meta name="layout" content="main_component">
     <title>Consent Group</title>
-    <script type="application/javascript">
-
-        const component = {
-            getUserUrl: "${createLink(controller: 'authenticated', action: 'getSessionUser')}",
-            searchUsersURL: "${createLink(controller: 'search', action: 'getMatchingUsers')}",
-            sampleSearchUrl: "${createLink(controller: 'consentGroup', action: 'unConsentedSampleCollections')}",
-            consentNamesSearchURL: "${createLink(controller: 'consentGroup', action: 'consentGroupSummaries')}",
-            createConsentGroupURL: "${createLink(controller:'newConsentGroup', action: 'save', uri: '/api/consent-group', method: 'POST')}",
-            attachDocumentsURL: "${createLink(uri: '/api/files-helper/attach-document', method: 'POST')}",
-            serverURL: "${webRequest.baseUrl}",
-            fillablePdfURL : "${createLink(controller: 'newConsentGroup', action: 'downloadFillablePDF', method: 'GET')}",
-            projectKey: "${params.projectKey}",
-            loadingImage: "${resource(dir: 'images', file: 'loading-indicator.svg')}",
-            projectType: '${params.type}'
-        };
-    </script>
 </head>
 <body>
 

--- a/grails-app/views/newProject/index.gsp
+++ b/grails-app/views/newProject/index.gsp
@@ -1,24 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="layout" content="main">
-    <meta charset="utf-8"/>
-
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.20.1/moment-with-locales.min.js"></script>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/react-bootstrap-table/4.3.1/react-bootstrap-table-all.min.css"/>
-    <link rel="stylesheet" href="https://unpkg.com/react-bootstrap-typeahead/css/Typeahead.css">
+    <meta name="layout" content="main_component">
     <title>Project</title>
-    <script type="application/javascript">
-
-        const component = {
-            getUserUrl: "${createLink(controller: 'authenticated', action: 'getSessionUser')}",
-            searchUsersURL: "${createLink(controller: 'search', action: 'getMatchingUsers')}",
-            attachDocumentsURL: "${createLink(uri: '/api/files-helper/attach-document', method: 'POST')}",
-            createProjectURL: "${createLink(controller:'project', action: 'save', uri: '/api/project', method: 'POST')}",
-            serverURL: "${webRequest.baseUrl}",
-            loadingImage: "${resource(dir: 'images', file: 'loading-indicator.svg')}"
-        };
-    </script>
 </head>
 <body>
 

--- a/grails-app/views/search/index.gsp
+++ b/grails-app/views/search/index.gsp
@@ -5,35 +5,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="layout" content="main">
-
-    <script type="application/javascript">
-        const issueTypes = [
-            <g:each status="count" in="${IssueType.values()}" var="type">"${raw(type.name)}"<g:if test="${count < IssueType.values().size() - 1}">,</g:if>
-            </g:each>];
-
-        const issueStatuses = [
-            <g:each status="count" in="${IssueStatus.values().sort{it.sequence}}" var="status">"${raw(status.name)}"<g:if test="${count < IssueStatus.values().size() - 1}">,</g:if>
-            </g:each>];
-
-        const irbs = [
-            <g:each status="count" in="${PreferredIrb.values()}" var="map">{ id:"${raw(map.key)}", value:"${raw(map.label)}"}<g:if test="${count < PreferredIrb.values().size() - 1}">,</g:if>
-            </g:each>];
-
-        // Using a component allows us to pass GSP values to javascript objects
-        const component = {
-            getUserUrl: "${createLink(controller: 'authenticated', action: 'getSessionUser')}",
-            searchUrl: "${createLink(controller: 'search', action: 'generalReactTablesJsonSearch')}",
-            projectKeySearchUrl: "${createLink(controller: 'search', action: 'projectKeyAutocomplete')}",
-            userNameSearchUrl: "${createLink(controller: 'search', action: 'getMatchingUsers')}",
-            issueTypes: issueTypes,
-            issueStatuses: issueStatuses,
-            irbs: irbs
-        };
-    </script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.20.1/moment-with-locales.min.js"></script>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/react-bootstrap-table/4.3.1/react-bootstrap-table-all.min.css"/>
-    <link rel="stylesheet" href="https://unpkg.com/react-bootstrap-typeahead/css/Typeahead.css">
+    <meta name="layout" content="main_component">
     <title>Search</title>
 </head>
 <body>


### PR DESCRIPTION
## Changes
* Make all of the primary react-based `index.gsp` files use the same template. 
* Pull all constants into the same object(s) so they can be reused.

## Testing
View search, project, consent group pages - should be no errors

## TODO
There is a lot we can do to refactor further, but I leave that for other PRs. This PR is meant to start us in the right direction in terms of consolidating react behavior. The more we can pull out of individual gsps, the easier it will be to consolidate them later on as well as convert other features more easily.

Also - this does not address the templates we are using (`_index.gsp` files). We need to figure that out too. 

---

- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Get a thumb from @rushtong
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
