### PR TITLE
[BTRX-623][risk=no] Convert footer to react

### DIFF
--- a/grails-app/views/layouts/main_component.gsp
+++ b/grails-app/views/layouts/main_component.gsp
@@ -26,6 +26,8 @@
     <link rel="stylesheet" href="//cdn.datatables.net/1.10.4/css/jquery.dataTables.min.css">
     <link rel="stylesheet" href="//cdn.datatables.net/tabletools/2.2.3/css/dataTables.tableTools.css">
     %{-- We need this custom table tools css file to override display issues with cdn version --}%
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/react-bootstrap-table/4.3.1/react-bootstrap-table-all.min.css"/>
+    <link rel="stylesheet" href="https://unpkg.com/react-bootstrap-typeahead/css/Typeahead.css"/>
 
     <asset:stylesheet src="jquery.dataTables.css"/>
     <asset:stylesheet src="style.css"/>
@@ -87,8 +89,6 @@
       }
     </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.20.1/moment-with-locales.min.js"></script>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/react-bootstrap-table/4.3.1/react-bootstrap-table-all.min.css"/>
-    <link rel="stylesheet" href="https://unpkg.com/react-bootstrap-typeahead/css/Typeahead.css"/>
 
     %{--
        Add all react component based code here.
@@ -134,6 +134,27 @@
       };
     </script>
 
+    %{-- Set context path for all scripts to use --}%
+    <script type="text/javascript">
+      window.appContext = '${request.contextPath}';
+    </script>
+
+    %{-- TODO: A lot of this code should go away once react conversion is complete --}%
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/jquery-ui.min.js"></script>
+    <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
+    <script src="//cdn.datatables.net/1.10.16/js/jquery.dataTables.min.js"></script>
+    <script src="//cdn.datatables.net/buttons/1.5.1/js/dataTables.buttons.min.js"></script>
+    <script src="//cdn.datatables.net/buttons/1.5.1/js/buttons.flash.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/jszip/3.1.3/jszip.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.32/pdfmake.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.32/vfs_fonts.js"></script>
+    <script src="//cdn.datatables.net/buttons/1.5.1/js/buttons.html5.min.js"></script>
+    <script src="//cdn.datatables.net/buttons/1.5.1/js/buttons.print.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.4/moment.min.js"></script>
+    <script src="//cdn.datatables.net/plug-ins/1.10.19/sorting/datetime-moment.js"></script>
+    <script src="https://cloud.tinymce.com/5/tinymce.min.js?apiKey=8zknubfnjvv9l3sg0cpxrome1qk6r2wlpdw7j4ebb3gjxige"></script>
+
     <g:layoutHead/>
 </head>
 <body>
@@ -169,11 +190,124 @@
     </div>
 </auth:broadSession>
 
-<div id="footer">
-    <div class="container">
-        <g:render template="/layouts/footer" />
-    </div>
+<div id="footer"></div>
+<asset:javascript src="build/footer.js"/>
+
+
+%{-- TODO: A lot of this code should go away once react conversion is complete --}%
+<asset:javascript src="jquery.fn.dataTablesExt.ticket.js"/>
+<asset:javascript src="jquery.fn.dataTablesExt.ticket.js"/>
+<asset:javascript src="chosen.jquery.min.js"/>
+<asset:javascript src="jasny-bootstrap.min.js"/>
+<asset:javascript src="jquery.validate.min.js"/>
+<asset:javascript src="jsrender.js"/>
+
+<asset:javascript src="jquery.file.upload-9.9.2/js/vendor/jquery.ui.widget.js"/>
+<asset:javascript src="jquery.file.upload-9.9.2/js/jquery.iframe-transport.js"/>
+<asset:javascript src="jquery.file.upload-9.9.2/js/jquery.fileupload.js"/>
+
+<script type="text/javascript">
+  $(document).ready(function () {
+    $(".chosen-select").chosen({width: "100%"});
+    initializeEditor();
+    $('[data-toggle="tooltip"]').tooltip();
+  });
+
+  function initializeEditor() {
+    tinymce.init({
+      selector:'textarea.editor',
+      width: '100%',
+      menubar: false,
+      statusbar: false,
+      plugins: "paste",
+      paste_data_images: false
+    });
+  }
+
+  function loadComments(url) {
+    $("#comments").load(
+      url,
+      function() {
+        $.fn.dataTable.moment( 'MM/DD/YYYY hh:mm:ss' );
+        $("#comments-table").DataTable({
+          dom: '<"H"Tfr><"pull-right"B><div>t</div><"F"lp>',
+          buttons: [ 'excelHtml5', 'csvHtml5', 'print' ],
+          language: { search: 'Filter:' },
+          pagingType: "full_numbers",
+          order: [1, "desc"]
+        });
+        initializeEditor();
+      }
+    );
+  }
+
+  function loadHistory(url) {
+    $("#history").load(
+      url,
+      function() {
+        $.fn.dataTable.moment( 'MM/DD/YYYY hh:mm:ss' );
+        $("#history-table").DataTable({
+          dom: '<"H"Tfr><"pull-right"B><div>t</div><"F"lp>',
+          buttons: [ 'excelHtml5', 'csvHtml5', 'print' ],
+          language: { search: 'Filter:' },
+          pagingType: "full_numbers",
+          order: [1, "desc"]
+        });
+      }
+    );
+  }
+
+  // Toggle pattern for Jira-style objects. Relies on "-id" naming pattern
+  function toggleContinueMessage(elementId, val1, val2) {
+    $("input[name='" + elementId + "-id'], input[name='" + elementId + "']").change(
+      function() {
+        if ($(this).val() === val1) {
+          $('*[data-id="' + val1 + '"]').show();
+          $('*[data-id="' + val2 + '"]').hide();
+        } else {
+          $('*[data-id="' + val1 + '"]').hide();
+          $('*[data-id="' + val2 + '"]').show();
+        }
+      }
+    );
+  }
+
+  // Toggle pattern for property style objects. Slightly different from Jira-style objects.
+  function togglePropertyMessage(elementName, val1, val2) {
+    $("input[name='" + elementName + "']").change(
+      function() {
+        prop1Message = $('*[data-id="' + elementName + "." + val1 + '"]');
+        prop2Message = $('*[data-id="' + elementName + "." + val2 + '"]');
+        if ($(this).val() === val1) {
+          prop1Message.show();
+          prop2Message.hide();
+        } else {
+          prop1Message.hide();
+          prop2Message.show();
+        }
+      }
+    );
+  }
+
+</script>
+
+<script id="uploadedFileTemplate" type="text/x-jsrender">
+<div class="alert alert-success" role="alert" id="{{:fileUuid}}">
+    <i class="fa {{:icon}}"></i>
+    <span style="padding-left: 10px;">{{:type}}: {{:name}}</span>
+    <i class="btn btn-danger fa fa-trash pull-right" onclick="removeDocument('{{:fileUuid}}', '{{:amendmentId}}');"></i>
 </div>
+</script>
+
+<asset:javascript src="application.js"/>
+
+<g:if test="${tab}">
+    <asset:script type="text/javascript">
+        $(document).ready(function () {
+            $('a[href="#${tab}"]').click();
+    });
+    </asset:script>
+</g:if>
 
 <asset:deferredScripts/>
 </body>

--- a/src/main/webapp/components/footer.js
+++ b/src/main/webapp/components/footer.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { a, div } from 'react-hyperscript-helpers'
+
+export class Footer extends React.Component {
+  render() {
+    const copy = div("Copyright © 2019 Eli & Edythe L. Broad Institute. All rights reserved. No unauthorized use or disclosure is permitted.");
+    const links = div({style: {margin: "3rem 0 1rem 0"}},
+      [
+        a({href: "https://www.broadinstitute.org/contact-us/privacy-policy-broad-institute-website", target: "_blank"}, "Privacy Policy"),
+        " | ",
+        a({href: "https://www.broadinstitute.org/contact-us/terms-and-conditions", target: "_blank"}, "Terms of Service")
+      ]
+    );
+    const well = div({className: "well"}, [copy, links]);
+    return div({className: "container"}, [well]);
+  }
+}
+
+ReactDOM.render(
+  <Footer/>,
+  document.getElementById("footer")
+);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,14 +6,15 @@ module.exports = {
   },
   entry: {
     collectionLinks: './src/main/webapp/collectionLinks/index.js',
-    search: './src/main/webapp/search/index.js',
-    project: './src/main/webapp/project/index.js',
     consentGroup: './src/main/webapp/consentGroup/index.js',
-    projectReview: './src/main/webapp/projectReview/index.js',
-    projectDocument: './src/main/webapp/projectDocument/index.js',
     consentGroupDocuments: './src/main/webapp/consentGroupDocuments/index.js',
     consentGroupReview: './src/main/webapp/consentGroupReview/index.js',
-    dataUseLetter: './src/main/webapp/dataUseLetter/index.js'
+    dataUseLetter: './src/main/webapp/dataUseLetter/index.js',
+    footer: './src/main/webapp/components/footer.js',
+    project: './src/main/webapp/project/index.js',
+    projectDocument: './src/main/webapp/projectDocument/index.js',
+    projectReview: './src/main/webapp/projectReview/index.js',
+    search: './src/main/webapp/search/index.js'
   },
   output: {
     path: path.join(__dirname, 'grails-app/assets/javascripts/build'),


### PR DESCRIPTION
## Addresses
See https://broadinstitute.atlassian.net/browse/BTRX-623

## Changes
* Add a footer component
* Load footer in the react template
* Add todos for removing outdated code once the conversion is complete.
* Changes to `main_component.gsp` are mainly copying the existing footer code so it can be in one place for later one when we remove all non-react dependencies. 
* Alphabetized files in `webpack.config.js`

## Testing
View both a react page (i.e. search) and a non-react page (i.e. about). Both should have the same footer and footer link behavior

---

- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Get a thumb from @rushtong
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
