### PR TITLE
BTRX - 602 & 591  - Put 'Add New Consent Group' button in Project review - Project type Api

### DIFF
--- a/grails-app/controllers/org/broadinstitute/orsp/UrlMappings.groovy
+++ b/grails-app/controllers/org/broadinstitute/orsp/UrlMappings.groovy
@@ -15,6 +15,7 @@ class UrlMappings {
         "/"(view:"/index")
         '/api/swagger/**'(controller: 'api', action: 'swagger')
         '/api/project'(resource: 'project')
+        '/api/project/get-type'(controller: 'project', action: 'getProjectType', method: 'GET')
         '/api/project/delete'(controller: 'project', action: 'delete', method: 'DELETE')
         '/api/files-helper/attach-document'(controller: 'fileHelper', action: 'attachDocument', method: 'POST')
         '/api/files-helper/attached-documents'(controller: 'fileHelper', action: 'attachedDocuments', method: 'GET')

--- a/grails-app/controllers/org/broadinstitute/orsp/api/ProjectController.groovy
+++ b/grails-app/controllers/org/broadinstitute/orsp/api/ProjectController.groovy
@@ -100,4 +100,16 @@ class ProjectController extends AuthenticatedController {
             transitionService.handleIntake(issue, actors*.userName, IssueStatus.SubmittingToORSP.name, getUser()?.displayName)
         }
     }
+
+    String getProjectType() {
+        String projectType = issueService.getProjectType(params.id)
+        if (projectType != null) {
+            response.status = 200
+            render([projectType: projectType] as JSON)
+        } else {
+            response.status = 404
+            render([message: "Project not found"] as JSON)
+        }
+        projectType
+    }
 }

--- a/grails-app/controllers/org/broadinstitute/orsp/api/ProjectController.groovy
+++ b/grails-app/controllers/org/broadinstitute/orsp/api/ProjectController.groovy
@@ -2,6 +2,7 @@ package org.broadinstitute.orsp.api
 
 import grails.converters.JSON
 import grails.rest.Resource
+import org.apache.commons.lang.StringUtils
 import org.broadinstitute.orsp.AuthenticatedController
 import org.broadinstitute.orsp.Funding
 import org.broadinstitute.orsp.Issue
@@ -103,7 +104,7 @@ class ProjectController extends AuthenticatedController {
 
     String getProjectType() {
         String projectType = issueService.getProjectType(params.id)
-        if (projectType != null) {
+        if (StringUtils.isNotEmpty(projectType)) {
             response.status = 200
             render([projectType: projectType] as JSON)
         } else {

--- a/grails-app/services/org/broadinstitute/orsp/IssueService.groovy
+++ b/grails-app/services/org/broadinstitute/orsp/IssueService.groovy
@@ -447,15 +447,8 @@ class IssueService {
     }
 
     String getProjectType(String projectKey) {
-        String projectType
         Issue issue = queryService.findByKey(projectKey)
-        if(issue != null) {
-            projectType = IssueType.valueOfName(issue.getType()).prefix.toLowerCase()
-            projectType
-        } else {
-            projectType = null
-        }
-        projectType
+        IssueType.valueOfName(issue?.getType())?.prefix?.toLowerCase()
     }
 
 }

--- a/grails-app/services/org/broadinstitute/orsp/IssueService.groovy
+++ b/grails-app/services/org/broadinstitute/orsp/IssueService.groovy
@@ -431,4 +431,16 @@ class IssueService {
         props
     }
 
+    String getProjectType(String projectKey) {
+        String projectType
+        Issue issue = queryService.findByKey(projectKey)
+        if(issue != null) {
+            projectType = IssueType.valueOfName(issue.getType()).prefix.toLowerCase()
+            projectType
+        } else {
+            projectType = null
+        }
+        projectType
+    }
+
 }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react-hyperscript-helpers": "2.0.0",
     "react-select": "2.1.2",
     "lodash": "4.17.11",
-    "date-fns": "1.30.1"
+    "date-fns": "1.30.1",
+    "regenerator-runtime": "0.13.2"
   }
 }

--- a/src/main/webapp/consentGroup/NewConsentGroup.js
+++ b/src/main/webapp/consentGroup/NewConsentGroup.js
@@ -4,7 +4,7 @@ import { NewConsentGroupDocuments } from './NewConsentGroupDocuments';
 import { NewConsentGroupGeneralData } from './NewConsentGroupGeneralData';
 import { InternationalCohorts } from '../components/InternationalCohorts';
 import { span, a } from 'react-hyperscript-helpers';
-import { Files, ConsentGroup, SampleCollections, User } from '../util/ajax';
+import { Files, ConsentGroup, SampleCollections, User, Project } from '../util/ajax';
 import { spinnerService } from '../util/spinner-service';
 import { DataSharing } from '../components/DataSharing';
 import { Security } from '../components/Security';
@@ -134,7 +134,11 @@ class NewConsentGroup extends Component {
   uploadFiles = (projectKey) => {
     Files.upload(this.props.attachDocumentsURL, this.state.files, projectKey, this.state.user.displayName, this.state.user.userName, true)
       .then(resp => {
-        window.location.href = this.getRedirectUrl();
+
+        Project.getProjectType(this.props.serverURL, this.props.projectKey).then(type => {
+          window.location.href =  [this.props.serverURL, type.data.projectType, "show", this.props.projectKey, "?tab=consent-groups"].join("/");
+        });
+        // window.location.href = this.getRedirectUrl();
         spinnerService.hideAll();
         this.setState(prev => {
           prev.formSubmitted = true;
@@ -226,10 +230,6 @@ class NewConsentGroup extends Component {
     }
     return renderSubmit;
   };
-
-  getRedirectUrl() {
-    return [this.props.serverURL, this.props.projectType, "show", this.props.projectKey, "?tab=consent-groups"].join("/");
-  }
 
   isValid = (field) => {
     let isValid = true;

--- a/src/main/webapp/consentGroup/NewConsentGroup.js
+++ b/src/main/webapp/consentGroup/NewConsentGroup.js
@@ -134,11 +134,9 @@ class NewConsentGroup extends Component {
   uploadFiles = (projectKey) => {
     Files.upload(this.props.attachDocumentsURL, this.state.files, projectKey, this.state.user.displayName, this.state.user.userName, true)
       .then(resp => {
-
         Project.getProjectType(this.props.serverURL, this.props.projectKey).then(type => {
           window.location.href =  [this.props.serverURL, type.data.projectType, "show", this.props.projectKey, "?tab=consent-groups"].join("/");
         });
-        // window.location.href = this.getRedirectUrl();
         spinnerService.hideAll();
         this.setState(prev => {
           prev.formSubmitted = true;

--- a/src/main/webapp/consentGroup/NewConsentGroup.js
+++ b/src/main/webapp/consentGroup/NewConsentGroup.js
@@ -131,12 +131,13 @@ class NewConsentGroup extends Component {
     });
   };
 
-  uploadFiles = (projectKey) => {
+  uploadFiles = async (projectKey) => {
+    let projectType = await Project.getProjectType(this.props.serverURL, this.props.projectKey);
     Files.upload(this.props.attachDocumentsURL, this.state.files, projectKey, this.state.user.displayName, this.state.user.userName, true)
       .then(resp => {
-        Project.getProjectType(this.props.serverURL, this.props.projectKey).then(type => {
-          window.location.href =  [this.props.serverURL, type.data.projectType, "show", this.props.projectKey, "?tab=consent-groups"].join("/");
-        });
+        // TODO: window.location.href is a temporal way to redirect the user to project's consent-group page tab. We need to change this after
+        // transitioning from old gsps style is solved.
+        window.location.href =  [this.props.serverURL, projectType, "show", this.props.projectKey, "?tab=consent-groups"].join("/");
         spinnerService.hideAll();
         this.setState(prev => {
           prev.formSubmitted = true;

--- a/src/main/webapp/project/NewProject.js
+++ b/src/main/webapp/project/NewProject.js
@@ -6,11 +6,12 @@ import { NewProjectDocuments } from './NewProjectDocuments';
 import { NE, NHSR, IRB } from './NewProjectDetermination';
 import { Files, Project, User } from '../util/ajax';
 import { isEmpty } from '../util/Utils';
-import { span } from 'react-hyperscript-helpers';
+import { span,button } from 'react-hyperscript-helpers';
 import { spinnerService } from '../util/spinner-service';
 import { InternationalCohorts } from '../components/InternationalCohorts';
 import { DataSharing } from "../components/DataSharing";
 import { Security } from '../components/Security';
+import "regenerator-runtime/runtime";
 
 class NewProject extends Component {
 
@@ -506,12 +507,13 @@ class NewProject extends Component {
     })
   };
 
-  uploadFiles = (projectKey) => {
+  uploadFiles = async (projectKey) => {
+    let projectType = await Project.getProjectType(this.props.serverURL, projectKey);
     Files.upload(this.props.attachDocumentsURL, this.state.files, projectKey, this.state.user.displayName, this.state.user.userName, true)
       .then(resp => {
-        Project.getProjectType(this.props.serverURL, projectKey).then(type => {
-          window.location.href =  [this.props.serverURL, type.data.projectType, "show", projectKey, "?tab=review"].join("/");
-        });
+        // TODO: window.location.href is a temporal way to redirect the user to new project's review page tab. We need to change this after
+        // transitioning from old gsps style is solved.
+        window.location.href =  [this.props.serverURL, projectType, "show", projectKey, "?tab=review"].join("/");
       }).catch(error => {
         spinnerService.hideAll();
         this.toggleTrueSubmitError();

--- a/src/main/webapp/project/NewProject.js
+++ b/src/main/webapp/project/NewProject.js
@@ -509,7 +509,9 @@ class NewProject extends Component {
   uploadFiles = (projectKey) => {
     Files.upload(this.props.attachDocumentsURL, this.state.files, projectKey, this.state.user.displayName, this.state.user.userName, true)
       .then(resp => {
-        window.location.href = this.getRedirectUrl(projectKey);
+        Project.getProjectType(this.props.serverURL, projectKey).then(type => {
+          window.location.href =  [this.props.serverURL, type.data.projectType, "show", projectKey, "?tab=review"].join("/");
+        });
       }).catch(error => {
         spinnerService.hideAll();
         this.toggleTrueSubmitError();
@@ -531,17 +533,6 @@ class NewProject extends Component {
       prev.generalError = false;
       return prev;
     });
-  }
-
-  getRedirectUrl(projectKey) {
-    let key = projectKey.split("-");
-    let projectType = '';
-    if (key.length === 3) {
-      projectType = key[1].toLowerCase();
-    } else {
-      projectType = key[0].toLowerCase();
-    }
-    return [this.props.serverURL, projectType, "show", projectKey,"?tab=review"].join("/");
   }
 
   render() {

--- a/src/main/webapp/projectReview/ProjectReview.js
+++ b/src/main/webapp/projectReview/ProjectReview.js
@@ -659,12 +659,20 @@ class ProjectReview extends Component {
           clarificationUrl: this.props.clarificationUrl,
           successClarification: this.successClarification
         }),
+        
         button({
           className: "btn buttonPrimary floatRight",
           style: { 'marginTop': '15px' },
           onClick: this.enableEdit(),
           isRendered: this.state.readOnly === true
         }, ["Edit Information"]),
+
+        button({
+          className: "btn buttonSecondary floatRight",
+          style: { 'marginTop': '15px' },
+          onClick: this.enableEdit(),
+          isRendered: this.state.readOnly === true,
+        }, ["Add New Consent Group"]),
 
         button({
           className: "btn buttonSecondary floatRight",

--- a/src/main/webapp/projectReview/ProjectReview.js
+++ b/src/main/webapp/projectReview/ProjectReview.js
@@ -611,6 +611,9 @@ class ProjectReview extends Component {
       return prev;
     });
   };
+  redirectToNewConsentGroup = () => {
+    window.location.href = this.props.serverURL + '/api/consent-group?projectKey=' + this.props.projectKey;
+  };
 
   render() {
     const { projectReviewApproved } = this.state.formData.projectExtraProps;
@@ -670,7 +673,7 @@ class ProjectReview extends Component {
         button({
           className: "btn buttonSecondary floatRight",
           style: { 'marginTop': '15px' },
-          onClick: this.enableEdit(),
+          onClick: this.redirectToNewConsentGroup,
           isRendered: this.state.readOnly === true,
         }, ["Add New Consent Group"]),
 

--- a/src/main/webapp/util/ajax.js
+++ b/src/main/webapp/util/ajax.js
@@ -133,6 +133,9 @@ export const Project = {
   updateProject(url, data, projectKey) {
     return axios.put(url + '?projectKey=' + projectKey, data);
   },
+  getProjectType(url, projectKey) {
+    return axios.get(url + '/api/project/get-type?id=' + projectKey);
+  }
 };
 
 export const DocumentHandler = {

--- a/src/main/webapp/util/ajax.js
+++ b/src/main/webapp/util/ajax.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import "regenerator-runtime/runtime";
 
 export const Search = {
 
@@ -133,8 +134,13 @@ export const Project = {
   updateProject(url, data, projectKey) {
     return axios.put(url + '?projectKey=' + projectKey, data);
   },
-  getProjectType(url, projectKey) {
-    return axios.get(url + '/api/project/get-type?id=' + projectKey);
+
+  async getProjectType(url, projectKey) {
+    let type = '';
+    await axios.get(url + '/api/project/get-type?id=' + projectKey)
+      .then(resp => type = resp.data.projectType)
+      .catch(err => console.error(err));
+    return type;
   }
 };
 


### PR DESCRIPTION
## Addresses
[BTRX-602](https://broadinstitute.atlassian.net/browse/BTRX-602): ORSP - Project Info tab: Put the new 'Add New Consent Group' button next to the 'Edit' button
[BTRX-591](https://broadinstitute.atlassian.net/browse/BTRX-591): ORSP - Technical debt - Create API to get project type

## Changes
- Code related to mapping `consentUpload` new variable (creation and update)
- Created a new backend api that returns a project type, given a projectKey. This was a technical debt.

##
**Note (Just as a discussion starter):**
 It would be really interesting to correct webpack.config in order to enable the use of async/await functionallity in our code. This would make promises handling easier and shorten our code. 

Apparently the problem is that `regeneratorRuntime` is undefined, this is due to  having a custom webpack.config where babel-polyfill is not being import. I tried to do it quickly here, but it demands a little more investigation. 

---

- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Get a thumb from @rushtong
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
