### PR TITLE
BTRX-627 ORSP - Several text changes

### DIFF
--- a/grails-app/views/notify/generalInfo.gsp
+++ b/grails-app/views/notify/generalInfo.gsp
@@ -8,10 +8,10 @@
 
     <div>
         <ol>
-            <li> As part of this project, will be Broad receive either personally identifiable information (PII) or protected health information (PHI)?
+            <li> As part of this project, will Broad receive either personally identifiable information (PII) or protected health information (PHI)?
                <p> <b> ${values.get("pii")} </p>
             </li>
-            <li> Are you bound by any regulatory compliance (FISMA, CLIA, etc.)? If yes, which one?
+            <li> Is this project subject to any regulations with specific data security requirements (FISMA, HIPAA, etc.)? If yes, which one?
                 <p> <b> ${values.get("compliance")} </p>
 
                 <g:if test="${values.get("textCompliance")}">
@@ -19,7 +19,7 @@
                 </g:if>
 
             </li>
-            <li> Does this data require additional protections beyond Broad’s standard data security measures? If yes, please explain.
+            <li> Does this data require additional protections beyond Broad's standard data security measures? If yes, please explain.
                <p> <b> ${values.get("sensitive")} </p>
 
                <g:if test="${values.get("textSensitive")}">
@@ -27,7 +27,7 @@
                </g:if>
 
             </li>
-            <li> Will the data collected or generated as part of this project be made available in an unrestricted/open-access environment (e.g. publicly available on the internet, shared via an open access repository such as GEO, etc.)? If yes, please explain.
+            <li> Will the data collected or generated as part of this project be made available in an unrestricted/open-access environment (e.g. publicly available on the internet, shared via an open access repository such as GEO, etc)? If yes, please explain.
                <p> <b> ${values.get("accessible")}</p>
 
                <g:if test="${values.get("textAccessible")}">

--- a/src/main/webapp/components/Fundings.js
+++ b/src/main/webapp/components/Fundings.js
@@ -168,7 +168,7 @@ export const Fundings = hh(class Fundings extends Component {
                 label({ className: "noMargin" }, ["Funding Source"])
               ]),
               div({ className: "col-lg-4 col-md-4 col-sm-4 col-12" }, [
-                label({ className: "noMargin" }, ["Prime Sponsor Name"])
+                label({ className: "noMargin" }, ["Sponsor Name"])
               ]),
               div({ className: "col-lg-4 col-md-4 col-sm-4 col-12" }, [
                 label({ className: "noMargin" }, ["Award Number/Identifier"])

--- a/src/main/webapp/components/InternationalCohorts.js
+++ b/src/main/webapp/components/InternationalCohorts.js
@@ -34,7 +34,7 @@ export const InternationalCohorts = hh(class InternationalCohorts extends Compon
     questions.push({
       question: span({}, [
         "Are samples or individual-level data sourced from a country in the European Economic Area? ", 
-        a({ href:"https://www.imf.org/external/pubs/ft/fandd/2014/03/europeaneconomicarea.htm", target: "_blank", className: "normal", style: { 'display': 'inline' } }, ["[https://www.imf.org/external/pubs/ft/fandd/2014/03/europeaneconomicarea.htm]"])
+        a({ href:"https://www.imf.org/external/pubs/ft/fandd/2014/03/europeaneconomicarea.htm", target: "_blank", className: "normal" }, ["[https://www.imf.org/external/pubs/ft/fandd/2014/03/europeaneconomicarea.htm]"])
     ]),
       yesOutput: 2,
       noOutput: EXIT,

--- a/src/main/webapp/components/InternationalCohorts.js
+++ b/src/main/webapp/components/InternationalCohorts.js
@@ -34,7 +34,7 @@ export const InternationalCohorts = hh(class InternationalCohorts extends Compon
     questions.push({
       question: span({}, [
         "Are samples or individual-level data sourced from a country in the European Economic Area? ", 
-        a({ href:"https://www.imf.org/external/pubs/ft/fandd/2014/03/europeaneconomicarea.htm", target: "_blank", className: "normal" }, ["[https://www.imf.org/external/pubs/ft/fandd/2014/03/europeaneconomicarea.htm]"])
+        a({ href:"https://www.imf.org/external/pubs/ft/fandd/2014/03/europeaneconomicarea.htm", target: "_blank", className: "normal" }, ["(List of member states of European Economic Area)"])
     ]),
       yesOutput: 2,
       noOutput: EXIT,

--- a/src/main/webapp/components/InternationalCohorts.js
+++ b/src/main/webapp/components/InternationalCohorts.js
@@ -1,5 +1,5 @@
 import { Component } from 'react';
-import { hh, h1, span } from 'react-hyperscript-helpers';
+import { hh, h1, span, a } from 'react-hyperscript-helpers';
 import { WizardStep } from './WizardStep';
 import { QuestionnaireWorkflow } from './QuestionnaireWorkflow';
 
@@ -32,7 +32,10 @@ export const InternationalCohorts = hh(class InternationalCohorts extends Compon
     let questions = [];
 
     questions.push({
-      question: span({}, ["Are samples or individual-level data sourced from a country in the European Economic Area? ", span({ className: "normal" }, ["[provide link to list of countries included]"])]),
+      question: span({}, [
+        "Are samples or individual-level data sourced from a country in the European Economic Area? ", 
+        a({ href:"https://www.imf.org/external/pubs/ft/fandd/2014/03/europeaneconomicarea.htm", target: "_blank", className: "normal", style: { 'display': 'inline' } }, ["[https://www.imf.org/external/pubs/ft/fandd/2014/03/europeaneconomicarea.htm]"])
+    ]),
       yesOutput: 2,
       noOutput: EXIT,
       answer: null,

--- a/src/main/webapp/components/InternationalCohorts.js
+++ b/src/main/webapp/components/InternationalCohorts.js
@@ -34,7 +34,7 @@ export const InternationalCohorts = hh(class InternationalCohorts extends Compon
     questions.push({
       question: span({}, [
         "Are samples or individual-level data sourced from a country in the European Economic Area? ", 
-        a({ href:"https://www.imf.org/external/pubs/ft/fandd/2014/03/europeaneconomicarea.htm", target: "_blank", className: "normal" }, ["(List of member states of European Economic Area)"])
+        a({ href:"https://www.imf.org/external/pubs/ft/fandd/2014/03/europeaneconomicarea.htm", target: "_blank", className: "normal" }, "(List of member states of European Economic Area)")
     ]),
       yesOutput: 2,
       noOutput: EXIT,

--- a/src/main/webapp/components/RequestClarificationDialog.js
+++ b/src/main/webapp/components/RequestClarificationDialog.js
@@ -98,7 +98,7 @@ export const RequestClarificationDialog = hh(class RequestClarificationDialog ex
 
           h(ModalFooter, {}, [
             button({ className: "btn buttonSecondary", disabled: this.state.disableBtn, onClick: this.handleClose }, ["Cancel"]),
-            button({ className: "btn buttonPrimary", disabled: this.state.disableBtn, onClick: this.submit }, ["Submit Clarification"])
+            button({ className: "btn buttonPrimary", disabled: this.state.disableBtn, onClick: this.submit }, ["Request Clarification"])
           ])
         ])
     )

--- a/src/main/webapp/components/Security.js
+++ b/src/main/webapp/components/Security.js
@@ -167,7 +167,7 @@ export const Security = hh(class Security extends Component {
           InputFieldRadio({
             id: "radioCompliance",
             name: "compliance",
-            label: span({}, ["Is this project subject to any regulations with specific data security requirements ", span({ className: 'normal' }, ["(FISMA, CLIA, etc.)"]), "?*"]),
+            label: span({}, ["Is this project subject to any regulations with specific data security requirements ", span({ className: 'normal' }, ["(FISMA, HIPPA, etc.)"]), "?*"]),
             value: this.state.formData.compliance,
             optionValues: ["true", "false", "uncertain"],
             optionLabels: [

--- a/src/main/webapp/components/Security.js
+++ b/src/main/webapp/components/Security.js
@@ -167,7 +167,7 @@ export const Security = hh(class Security extends Component {
           InputFieldRadio({
             id: "radioCompliance",
             name: "compliance",
-            label: span({}, ["Is this project subject to any regulations with specific data security requirements ", span({ className: 'normal' }, ["(FISMA, HIPPA, etc.)"]), "?*"]),
+            label: span({}, ["Is this project subject to any regulations with specific data security requirements ", span({ className: 'normal' }, ["(FISMA, HIPAA, etc.)"]), "?*"]),
             value: this.state.formData.compliance,
             optionValues: ["true", "false", "uncertain"],
             optionLabels: [

--- a/src/main/webapp/components/SecurityReview.js
+++ b/src/main/webapp/components/SecurityReview.js
@@ -82,7 +82,7 @@ export const SecurityReview = hh(class SecurityReview extends Component {
       InputFieldRadio({
         id: "radioCompliance",
         name: "compliance",
-        label: span({}, ["Is this project subject to any regulations with specific data security requirements ", span({ className: 'normal' }, ["(FISMA, CLIA, etc.)"]), "?*"]),
+        label: span({}, ["Is this project subject to any regulations with specific data security requirements ", span({ className: 'normal' }, ["(FISMA, HIPPA, etc.)"]), "?*"]),
         value: this.props.review === true ? this.props.formData.projectExtraProps.compliance : this.props.currentValue.securityInfoFormData.compliance,
         currentValue: this.props.review === true ? this.props.current.projectExtraProps.compliance : null,
         optionValues: ["true", "false", "uncertain"],

--- a/src/main/webapp/components/SecurityReview.js
+++ b/src/main/webapp/components/SecurityReview.js
@@ -82,7 +82,7 @@ export const SecurityReview = hh(class SecurityReview extends Component {
       InputFieldRadio({
         id: "radioCompliance",
         name: "compliance",
-        label: span({}, ["Is this project subject to any regulations with specific data security requirements ", span({ className: 'normal' }, ["(FISMA, HIPPA, etc.)"]), "?*"]),
+        label: span({}, ["Is this project subject to any regulations with specific data security requirements ", span({ className: 'normal' }, ["(FISMA, HIPAA, etc.)"]), "?*"]),
         value: this.props.review === true ? this.props.formData.projectExtraProps.compliance : this.props.currentValue.securityInfoFormData.compliance,
         currentValue: this.props.review === true ? this.props.current.projectExtraProps.compliance : null,
         optionValues: ["true", "false", "uncertain"],

--- a/src/main/webapp/components/Wizard.js
+++ b/src/main/webapp/components/Wizard.js
@@ -1,5 +1,5 @@
 import { Component, Fragment } from 'react';
-import { div, hh, h2, h, button, h1, p } from 'react-hyperscript-helpers';
+import { div, hh, h3, h, button, h1, p } from 'react-hyperscript-helpers';
 import './Wizard.css';
 import { Spinner } from './Spinner';
 
@@ -77,6 +77,7 @@ export const Wizard = hh(class Wizard extends Component {
     return (
       div({ className: "wizardWrapper" }, [
         h1({ className: "wizardTitle" }, [this.props.title]),
+        h3({ isRendered: this.props.note !== undefined, className: "italic" }, [this.props.note]),
         div({ className: "wizardContainer" }, [
           div({ className: "tabContainer" }, [
             this.props.children.map((child, idx) => {

--- a/src/main/webapp/consentGroup/NewConsentGroup.js
+++ b/src/main/webapp/consentGroup/NewConsentGroup.js
@@ -563,6 +563,7 @@ class NewConsentGroup extends Component {
     return (
       Wizard({
         title: "New Consent Group",
+        note: "Note that this application cannot be saved and returned to for completion later. However, allowing the page to remain open in your browser will permit you to return to the application at any time.",
         stepChanged: this.stepChanged,
         isValid: this.isValid,
         showSubmit: this.showSubmit,

--- a/src/main/webapp/consentGroupReview/ConsentGroupReview.js
+++ b/src/main/webapp/consentGroupReview/ConsentGroupReview.js
@@ -905,7 +905,7 @@ class ConsentGroupReview extends Component {
     questions.push({
       question: span({}, [
         "Are samples or individual-level data sourced from a country in the European Economic Area? ",
-        a({ href: "https://www.imf.org/external/pubs/ft/fandd/2014/03/europeaneconomicarea.htm", target: "_blank", className: "normal" }, ["(List of member states of European Economic Area)"])
+        a({ href: "https://www.imf.org/external/pubs/ft/fandd/2014/03/europeaneconomicarea.htm", target: "_blank", className: "normal" }, "(List of member states of European Economic Area)")
       ]),
       yesOutput: 2,
       noOutput: EXIT,

--- a/src/main/webapp/consentGroupReview/ConsentGroupReview.js
+++ b/src/main/webapp/consentGroupReview/ConsentGroupReview.js
@@ -592,7 +592,7 @@ class ConsentGroupReview extends Component {
 
   toggleState = (e) => () => {
     this.setState((state, props) => {
-      return { [e]: !state[e]}
+      return { [e]: !state[e] }
     });
   };
 
@@ -656,7 +656,7 @@ class ConsentGroupReview extends Component {
   };
 
   institutionalSrcHasErrors = () => {
-    const instSources = this.state.formData.instSources == undefined ? [{current: {name: '', country: ''}, future: {name: '', country: ''}}] : this.state.formData.instSources;
+    const instSources = this.state.formData.instSources == undefined ? [{ current: { name: '', country: '' }, future: { name: '', country: '' } }] : this.state.formData.instSources;
     let institutionalNameErrorIndex = [];
     let institutionalCountryErrorIndex = [];
     let institutionalError = instSources.filter((obj, idx) => {
@@ -903,7 +903,10 @@ class ConsentGroupReview extends Component {
     const questions = [];
 
     questions.push({
-      question: span({}, ["Are samples or individual-level data sourced from a country in the European Economic Area? ", span({ className: "normal" }, ["[provide link to list of countries included]"])]),
+      question: span({}, [
+        "Are samples or individual-level data sourced from a country in the European Economic Area? ",
+        a({ href: "https://www.imf.org/external/pubs/ft/fandd/2014/03/europeaneconomicarea.htm", target: "_blank", className: "normal" }, ["(List of member states of European Economic Area)"])
+      ]),
       yesOutput: 2,
       noOutput: EXIT,
       answer: null,
@@ -1111,7 +1114,7 @@ class ConsentGroupReview extends Component {
       isCollaboratorProvidingGoodService = '',
       isConsentUnambiguous = '',
     } = get(this.state.formData, 'consentExtraProps', '');
-    const instSources = this.state.formData.instSources == undefined ? [{current: {name: '', country: ''}, future: {name: '', country: ''}}] : this.state.formData.instSources;
+    const instSources = this.state.formData.instSources == undefined ? [{ current: { name: '', country: '' }, future: { name: '', country: '' } }] : this.state.formData.instSources;
 
     let currentEndDate = this.state.current.consentExtraProps.endDate !== null ? format(new Date(this.state.current.consentExtraProps.endDate), 'MM/DD/YYYY') : null;
     let currentStartDate = this.state.current.consentExtraProps.startDate !== null ? format(new Date(this.state.current.consentExtraProps.startDate), 'MM/DD/YYYY') : null;
@@ -1295,7 +1298,7 @@ class ConsentGroupReview extends Component {
             div({ className: "col-lg-4 col-md-4 col-sm-4 col-12" }, [
               InputFieldDatePicker({
                 selected: startDate,
-                value: startDate !== null ? format(new Date(startDate), 'MM/DD/YYYY'): null,
+                value: startDate !== null ? format(new Date(startDate), 'MM/DD/YYYY') : null,
                 currentValue: currentStartDate,
                 name: "startDate",
                 label: "Start Date",

--- a/src/main/webapp/consentGroupReview/ConsentGroupReview.js
+++ b/src/main/webapp/consentGroupReview/ConsentGroupReview.js
@@ -1454,7 +1454,7 @@ class ConsentGroupReview extends Component {
           InputFieldRadio({
             id: "radioCompliance",
             name: "compliance",
-            label: span({}, ["Are you bound by any regulatory compliance ", span({ className: 'normal' }, ["(FISMA, HIPPA, etc.)"]), "?"]),
+            label: span({}, ["Are you bound by any regulatory compliance ", span({ className: 'normal' }, ["(FISMA, HIPAA, etc.)"]), "?"]),
             value: this.state.formData.consentExtraProps.compliance,
             currentValue: this.state.current.consentExtraProps.compliance,
             optionValues: ["true", "false", "uncertain"],

--- a/src/main/webapp/consentGroupReview/ConsentGroupReview.js
+++ b/src/main/webapp/consentGroupReview/ConsentGroupReview.js
@@ -1454,7 +1454,7 @@ class ConsentGroupReview extends Component {
           InputFieldRadio({
             id: "radioCompliance",
             name: "compliance",
-            label: span({}, ["Are you bound by any regulatory compliance ", span({ className: 'normal' }, ["(FISMA, CLIA, etc.)"]), "?"]),
+            label: span({}, ["Are you bound by any regulatory compliance ", span({ className: 'normal' }, ["(FISMA, HIPPA, etc.)"]), "?"]),
             value: this.state.formData.consentExtraProps.compliance,
             currentValue: this.state.current.consentExtraProps.compliance,
             optionValues: ["true", "false", "uncertain"],

--- a/src/main/webapp/index.css
+++ b/src/main/webapp/index.css
@@ -21,6 +21,7 @@ h2 {
 
 h3 {
   font-size: 1.2rem;
+  line-height: 1.3;
 }
 
 hr {

--- a/src/main/webapp/project/NewProject.js
+++ b/src/main/webapp/project/NewProject.js
@@ -550,6 +550,7 @@ class NewProject extends Component {
     return (
       Wizard({
         title: "New Project",
+        note: "Note that this application cannot be saved and returned to for completion later. However, allowing the page to remain open in your browser will permit you to return to the application at any time.",
         stepChanged: this.stepChanged,
         isValid: this.isValid,
         submitHandler: this.submitNewProject,

--- a/src/main/webapp/project/NewProjectDetermination.js
+++ b/src/main/webapp/project/NewProjectDetermination.js
@@ -72,8 +72,7 @@ export const NewProjectDetermination = hh(class NewProjectDetermination extends 
     });
 
     questions.push({
-      question: 'Are samples/data being provied by an investigator who has identifiers or obtains samples through and interaction ',
-      moreInfo: '(i.e. is conductin HSR)?',
+      question: 'Are samples/data being provided by an investigator who has access to identifiers or obtains samples through an intervention or interaction? ',
       progress: 50,
       yesOutput: 6,
       noOutput: NHSR,

--- a/src/main/webapp/projectReview/ProjectReview.js
+++ b/src/main/webapp/projectReview/ProjectReview.js
@@ -1155,8 +1155,7 @@ class ProjectReview extends Component {
               name: "interactionSource",
               value: this.state.formData.projectExtraProps.interactionSource,
               currentValue: this.state.current.projectExtraProps.interactionSource,
-              moreInfo: '(i.e. is conductin HSR)?',
-              label: 'Are samples/data being provied by an investigator who has identifiers or obtains samples through and interaction ',
+              label: 'Are samples/data being provided by an investigator who has access to identifiers or obtains samples through an intervention or interaction?',
               readOnly: true,
               onChange: () => { }
             })


### PR DESCRIPTION
## Addresses

Page/s: Consent Group creation and review
Update the first International Cohorts question to include the link: “Are samples or individual-level data sourced from a country in the European Economic Area? https://www.imf.org/external/pubs/ft/fandd/2014/03/europeaneconomicarea.htm”

Page: Project/Consent Group creation
Add the following text below the main page title on both Project and Consent Group creation workflows: “Note that this application cannot be saved and returned to for completion later. However, allowing the page to remain open in your browser will permit you to return to the application at any time.”

Pages: Project review > Request Clarification dialog
Change text on Clarifications popup box button to say ‘Request Clarification’ instead of ‘Submit Clarification’

Page/s: Project creation and review
Update the text of the Determination Question (see attached image below) to: “Are samples/data being provided by an investigator who has access to identifiers or obtains samples through an intervention or interaction?”

Page/s: Project/Consent Group creation and review
In the second question on the Security tab, remove “CLIA” and write “HIPAA”

Page/s: Project creation and review
Remove ‘Prime’ before ‘Sponsor Name” in the Funding box of the General Data/Project Details tab

## Changes

## Testing

---

- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Get a thumb from @rushtong
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
