### PR TITLE
[BTRX-583] Copy DUL link to clipboard

### DIFF
--- a/src/main/webapp/components/AddDocumentDialog.js
+++ b/src/main/webapp/components/AddDocumentDialog.js
@@ -1,5 +1,5 @@
 import { Component } from 'react';
-import { hh, div, h, p, small, span, br, button } from 'react-hyperscript-helpers';
+import { hh, div, h, p, small, span, br, button, textarea } from 'react-hyperscript-helpers';
 import { Modal, ModalHeader, ModalTitle, ModalFooter, ModalBody } from 'react-bootstrap';
 import { InputFieldSelect } from './InputFieldSelect';
 import { InputFieldFile } from './InputFieldFile';
@@ -36,26 +36,41 @@ export const AddDocumentDialog = hh(class AddDocumentDialog extends Component {
     };
     this.upload = this.upload.bind(this);
     this.handleTypeSelect = this.handleTypeSelect.bind(this);
+    this.getShareableLink = this.getShareableLink.bind(this);
   }
+
+  copyLinkToClipboard = (e, link) => {
+    const textLink = document.getElementById('textLink');
+    textLink.value = 'texto del link';
+    textLink.select();
+    const out = document.execCommand('copy');
+    console.log(out);
+  };
 
   getShareableLink = () => {
     let data = {
       consentGroupKey: this.props.projectKey,
       creator: this.props.user.userName
     };
-    DUL.generateRedirectLink(data, this.props.serverURL).then(data => {
-      window.location.href = this.props.serverURL + "/dataUseLetter/show?id=" + data.data.dulToken;
-    }).catch(
-      error => {
-        this.setState(prev => {
-          prev.disableBtn = false;
-          prev.alertType ="danger";
-          prev.alertMessage = 'Something went wrong. Please try again.';
-          prev.showAlert = true;
-          return prev;
-        })
-      }
-    );
+    DUL.generateRedirectLink(data, this.props.serverURL).then(resp => {
+      console.log(resp.data.dulToken);
+      // link = this.props.serverURL + "/dataUseLetter/show?id=" + data.data.dulToken;
+      this.copyLinkToClipboard(resp.data.dulToken);
+      this.setState(prev => {
+        prev.alertType = "success";
+        prev.alertMessage = "Link copied to clipboard!";
+        prev.showAlert = true;
+        return prev;
+      });
+    }).catch(error => {
+      this.setState(prev => {
+        prev.disableBtn = false;
+        prev.alertType = "danger";
+        prev.alertMessage = 'Something went wrong. Please try again.';
+        prev.showAlert = true;
+        return prev;
+      });
+    });
   };
 
   redirectToDul = () => {
@@ -271,6 +286,7 @@ export const AddDocumentDialog = hh(class AddDocumentDialog extends Component {
               errorMessage: "Required field",
               removeHandler: () => this.removeFile(document)
             }),
+            textarea({id: 'textLink'}, []),
             div({ isRendered: this.state.type.value === 'Data Use Letter', style: { 'marginTop': '10px' } }, [
               p({ className: "bold" }, [
                 "Do you want to send a Data Use Letter form directly to your Collaborator for their IRB's completion?",
@@ -298,7 +314,12 @@ export const AddDocumentDialog = hh(class AddDocumentDialog extends Component {
               ]),
               div({ className: "row" }, [
                 div({ className: "col-lg-6 col-md-6 col-sm-6 col-6" }, [
-                  button({ className: "btn buttonSecondary fullWidth", onClick: this.getShareableLink, disabled: true }, [
+                  button({
+                    className: "btn buttonSecondary fullWidth",
+                    onClick: this.getShareableLink,
+                    name: "getLink",
+                    disabled: false
+                  }, [
                     span({ className: "glyphicon glyphicon-link", style: { 'marginRight': '5px' } }, []),
                     "Get shareable link"
                   ])

--- a/src/main/webapp/components/AddDocumentDialog.js
+++ b/src/main/webapp/components/AddDocumentDialog.js
@@ -39,29 +39,14 @@ export const AddDocumentDialog = hh(class AddDocumentDialog extends Component {
     this.getShareableLink = this.getShareableLink.bind(this);
   }
 
-  copyLinkToClipboard = (e, link) => {
-    const textLink = document.getElementById('textLink');
-    textLink.value = 'texto del link';
-    textLink.select();
-    const out = document.execCommand('copy');
-    console.log(out);
-  };
-
   getShareableLink = () => {
     let data = {
       consentGroupKey: this.props.projectKey,
       creator: this.props.user.userName
     };
     DUL.generateRedirectLink(data, this.props.serverURL).then(resp => {
-      console.log(resp.data.dulToken);
-      // link = this.props.serverURL + "/dataUseLetter/show?id=" + data.data.dulToken;
-      this.copyLinkToClipboard(resp.data.dulToken);
-      this.setState(prev => {
-        prev.alertType = "success";
-        prev.alertMessage = "Link copied to clipboard!";
-        prev.showAlert = true;
-        return prev;
-      });
+      navigator.clipboard.writeText(this.props.serverURL + "/dataUseLetter/show?id=" + resp.data.dulToken);
+      this.successTimeAlert();
     }).catch(error => {
       this.setState(prev => {
         prev.disableBtn = false;
@@ -70,6 +55,25 @@ export const AddDocumentDialog = hh(class AddDocumentDialog extends Component {
         prev.showAlert = true;
         return prev;
       });
+    });
+  };
+
+  successTimeAlert = () => {
+    setTimeout(this.removeAlertMessage, 3000, null);
+    this.setState(prev => {
+      prev.alertType = "success";
+      prev.alertMessage = "Link copied to clipboard!";
+      prev.showAlert = true;
+      return prev;
+    });
+  };
+
+  removeAlertMessage = () => {
+    this.setState(prev => {
+      prev.alertType = "success";
+      prev.alertMessage = "";
+      prev.showAlert = false;
+      return prev;
     });
   };
 
@@ -317,7 +321,8 @@ export const AddDocumentDialog = hh(class AddDocumentDialog extends Component {
                     className: "btn buttonSecondary fullWidth",
                     onClick: this.getShareableLink,
                     name: "getLink",
-                    disabled: false
+                    disabled: false,
+                    id: 'shareable-link'
                   }, [
                     span({ className: "glyphicon glyphicon-link", style: { 'marginRight': '5px' } }, []),
                     "Get shareable link"


### PR DESCRIPTION
## Addresses
Every time the user clicks _Get sherable link_ a new token is generated and then copied to the OS clipboard. https://broadinstitute.atlassian.net/browse/BTRX-583
## Changes
Added a new function of _navigator_ API of the browser. To see more about the support across platforms this is a good reference https://caniuse.com/#search=clipboard
## Testing

---

- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Get a thumb from @rushtong
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
