### PR TITLE
BTRX - 631 - Make federal prime award number required in Fundings

### DIFF
--- a/src/main/webapp/components/Fundings.js
+++ b/src/main/webapp/components/Fundings.js
@@ -3,6 +3,7 @@ import { input, hh, h, div, p, hr, small, label } from 'react-hyperscript-helper
 import { InputFieldText } from './InputFieldText';
 import { InputFieldSelect } from './InputFieldSelect';
 import { Btn } from './Btn';
+import { isEmpty } from "../util/Utils";
 
 const fundingOptions = [
   { value: 'federal_prime', label: 'Federal Prime' },
@@ -154,6 +155,15 @@ export const Fundings = hh(class Fundings extends Component {
     return hasError
   };
 
+  getIdentifierError = (element) => {
+    let identifierHasError = false;
+    const source = this.props.edit ? element.future.source : element.source;
+    if (this.props.fundingAwardNumberError && source.value === 'federal_prime') {
+      identifierHasError = this.props.edit ? isEmpty(element.future.identifier): isEmpty(element.identifier)
+    }
+    return identifierHasError;
+  };
+
   render() {
     let {
       fundings = [],
@@ -227,6 +237,8 @@ export const Fundings = hh(class Fundings extends Component {
                       index: idx,
                       name: "identifier",
                       label: "",
+                      error: this.getIdentifierError(rd),
+                      errorMessage: this.props.errorMessage,
                       value: this.props.edit ? rd.future.identifier: rd.identifier,
                       currentValue: this.props.edit ? current[idx].current.identifier : rd.identifier,
                       disabled: false,

--- a/src/main/webapp/project/NewProject.js
+++ b/src/main/webapp/project/NewProject.js
@@ -61,7 +61,8 @@ class NewProject extends Component {
         pTitle: false,
         uploadConsentGroup: false,
         subjectProtection: false,
-        fundings: false
+        fundings: false,
+        fundingAwardNumber: false
       },
       formerProjectType: null,
       infoSecurityErrors: {
@@ -296,6 +297,8 @@ class NewProject extends Component {
     let subjectProtection = false;
     let isValid = true;
     let fundings = false;
+    let fundingAwardNumber = false;
+
     if (isEmpty(this.state.generalDataFormData.studyDescription)) {
       studyDescription = true;
       isValid = false;
@@ -321,6 +324,10 @@ class NewProject extends Component {
           fundings = true;
           isValid = false;
         }
+        if (!fundings && funding.source.value === 'federal_prime' && isEmpty(funding.identifier)) {
+          fundingAwardNumber = true;
+          isValid = false;
+        }
       });
     }
     if (field === undefined || field === null || field === 0) {
@@ -330,6 +337,7 @@ class NewProject extends Component {
         prev.errors.subjectProtection = subjectProtection;
         prev.errors.pTitle = pTitle;
         prev.errors.fundings = fundings;
+        prev.errors.fundingAwardNumber = fundingAwardNumber;
         return prev;
       });
     }
@@ -339,6 +347,7 @@ class NewProject extends Component {
       this.setState(prev => {
         if (field === 'fundings') {
           prev.errors.fundings = fundings;
+          prev.errors.fundingAwardNumber = fundingAwardNumber;
         }
         else if (field === 'studyDescription') {
           prev.errors.studyDescription = studyDescription;

--- a/src/main/webapp/project/NewProjectGeneralData.js
+++ b/src/main/webapp/project/NewProjectGeneralData.js
@@ -169,7 +169,7 @@ export const NewProjectGeneralData = hh(class NewProjectGeneralData extends Comp
     return (
       WizardStep({
         title: this.props.title, step: 0, currentStep: this.props.currentStep,
-        error: this.props.errors.fundings || this.props.errors.studyDescription || this.props.errors.pTitle || this.props.errors.uploadConsentGroup || this.props.errors.subjectProtection,
+        error: this.props.errors.fundings || this.props.errors.fundingAwardNumber || this.props.errors.studyDescription || this.props.errors.pTitle || this.props.errors.uploadConsentGroup || this.props.errors.subjectProtection,
         errorMessage: 'Please complete all required fields'}, [
         Panel({ title: "Requestor Information ", moreInfo: "(person filling the form)", tooltipLabel: "?", tooltipMsg: "Future correspondence regarding this project will be directed to this individual" }, [
           InputFieldText({
@@ -224,6 +224,7 @@ export const NewProjectGeneralData = hh(class NewProjectGeneralData extends Comp
             fundings: this.state.formData.fundings,
             updateFundings: this.handleUpdateFundings,
             error: this.props.errors.fundings,
+            fundingAwardNumberError: this.props.errors.fundingAwardNumber,
             errorMessage: "Required field",
             edit: false
           }),

--- a/src/main/webapp/projectReview/ProjectReview.js
+++ b/src/main/webapp/projectReview/ProjectReview.js
@@ -39,6 +39,7 @@ class ProjectReview extends Component {
       fundingError: false,
       fundingErrorIndex: [],
       internationalCohortsError: false,
+      fundingAwardNumberError: false,
       showDialog: false,
       approveInfoDialog: false,
       discardEditsDialog: false,
@@ -669,6 +670,8 @@ class ProjectReview extends Component {
   handleUpdateFundings = (updated) => {
     this.setState(prev => {
       prev.formData.fundings = updated;
+      prev.fundingAwardNumberError = false;
+      prev.generalError = false;
       prev.fundingError = false;
       return prev;
     });
@@ -782,13 +785,17 @@ class ProjectReview extends Component {
     let generalError = false;
     let intCohortsAnswers = false;
     let questions = false;
-
-    // Todo: Fundings error will be handled inside its component
+    let fundingAwardNumber = false;
+// DEBUGUBUGU
     let fundingError = this.state.formData.fundings.filter((obj, idx) => {
       if (isEmpty(obj.future.source.label) && (!isEmpty(obj.future.sponsor) || !isEmpty(obj.future.identifier))
         || (idx === 0 && isEmpty(obj.future.source.label) && isEmpty(obj.current.source.label))) {
         fundingErrorIndex.push(idx);
+        // fundingAwardNumber = obj.future.source.value === 'federal_prime' && isEmpty(obj.future.identifier);
         return true
+      } else if (obj.future.source.value === 'federal_prime' && isEmpty(obj.future.identifier)) {
+        fundingAwardNumber = obj.future.source.value === 'federal_prime' && isEmpty(obj.future.identifier);
+        return true;
       } else {
         return false;
       }
@@ -841,7 +848,8 @@ class ProjectReview extends Component {
       prev.generalError = generalError;
       prev.showInfoSecurityError = infoSecValidate;
       prev.internationalCohortsError = intCohortsAnswers;
-    return prev;
+      prev.fundingAwardNumberError = fundingAwardNumber;
+      return prev;
     });
 
     return !uploadConsentGroupError &&
@@ -852,6 +860,7 @@ class ProjectReview extends Component {
       !editDescriptionError &&
       !fundingError &&
       !questions &&
+      !fundingAwardNumber &&
       this.validateInfoSecurity();
   }
 
@@ -1137,6 +1146,7 @@ class ProjectReview extends Component {
             readOnly: this.state.readOnly,
             error: this.state.fundingError,
             errorIndex: this.state.fundingErrorIndex,
+            fundingAwardNumberError: this.state.fundingAwardNumberError,
             setError: this.changeFundingError,
             errorMessage: "Required field",
             edit: true

--- a/src/main/webapp/projectReview/ProjectReview.js
+++ b/src/main/webapp/projectReview/ProjectReview.js
@@ -786,12 +786,10 @@ class ProjectReview extends Component {
     let intCohortsAnswers = false;
     let questions = false;
     let fundingAwardNumber = false;
-// DEBUGUBUGU
     let fundingError = this.state.formData.fundings.filter((obj, idx) => {
       if (isEmpty(obj.future.source.label) && (!isEmpty(obj.future.sponsor) || !isEmpty(obj.future.identifier))
         || (idx === 0 && isEmpty(obj.future.source.label) && isEmpty(obj.current.source.label))) {
         fundingErrorIndex.push(idx);
-        // fundingAwardNumber = obj.future.source.value === 'federal_prime' && isEmpty(obj.future.identifier);
         return true
       } else if (obj.future.source.value === 'federal_prime' && isEmpty(obj.future.identifier)) {
         fundingAwardNumber = obj.future.source.value === 'federal_prime' && isEmpty(obj.future.identifier);


### PR DESCRIPTION
## Addresses
[BTRX-631](https://broadinstitute.atlassian.net/browse/BTRX-631): ORSP - Make award number required on federal primer funding.

## Changes
- Added extra validation for Fundings.
- Modify Ui to display required warning.

## Testing
- Try to submit a new project or an edit suggestion in review project having a `Federeal Prime`  funding and leaving its Award Number empty. It should validate this last field as required. 
- Award number is not required for the remaining 'fundings'.

---

- [x] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Get a thumb from @rushtong
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
