### PR TITLE
BTRX - 628 - Feedback after submission Project & CG 

### DIFF
--- a/grails-app/views/consentGroup/list.gsp
+++ b/grails-app/views/consentGroup/list.gsp
@@ -12,6 +12,11 @@
 
 <g:if test="${consentGroups}">
     <h3>Consent Groups</h3>
+
+    <div id="alert" class="alert alert-success" style="display:none;" >
+        <p>Your Consent Group was successfully submitted to the Broad Institute’s Office of Research Subject Protection. It will now be reviewed by the ORSP team who will reach out to you if they have any questions.</p>
+    </div>
+
     <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
         <g:each in="${consentGroups}" var="consent" status="panelIndex">
             <div class="panel panel-default">
@@ -97,3 +102,16 @@
 
 </body>
 </html>
+
+
+<script>
+// Display for 8 seconds a message indicating the submission of a new consent group. This is temporal until this page is moved to react.
+    $( document ).ready(function(){
+        var url = new URLSearchParams(window.location.search);
+        if (url.get('tab') === 'consent-groups' && url.has('new')) {
+            $('#alert').fadeIn('slow', function(){
+                   $('#alert').delay(8000).fadeOut();
+            });
+        }
+    });
+</script>

--- a/grails-app/views/consentGroup/list.gsp
+++ b/grails-app/views/consentGroup/list.gsp
@@ -105,7 +105,7 @@
 
 
 <script>
-// Display for 8 seconds a message indicating the submission of a new consent group. This is temporal until this page is moved to react.
+// Display for 8 seconds a message indicating the submission of a new consent group. This is temporary until this page is moved to react.
     $( document ).ready(function(){
         var url = new URLSearchParams(window.location.search);
         if (url.get('tab') === 'consent-groups' && url.has('new')) {

--- a/src/main/webapp/components/RequestClarificationDialog.js
+++ b/src/main/webapp/components/RequestClarificationDialog.js
@@ -40,7 +40,7 @@ export const RequestClarificationDialog = hh(class RequestClarificationDialog ex
         this.setState(prev => {
           prev.showAlert = false;
         });
-        this.props.successClarification();
+        this.props.successClarification('showSuccessClarification', 'Request clarification sent.');
         this.handleClose();
       }).catch(error => {
         console.log(error);

--- a/src/main/webapp/components/RequestClarificationDialog.js
+++ b/src/main/webapp/components/RequestClarificationDialog.js
@@ -40,7 +40,7 @@ export const RequestClarificationDialog = hh(class RequestClarificationDialog ex
         this.setState(prev => {
           prev.showAlert = false;
         });
-        this.props.successClarification('showSuccessClarification', 'Request clarification sent.');
+        this.props.successClarification('showSuccessClarification', 'Request clarification sent.', 5000);
         this.handleClose();
       }).catch(error => {
         console.log(error);

--- a/src/main/webapp/consentGroup/NewConsentGroup.js
+++ b/src/main/webapp/consentGroup/NewConsentGroup.js
@@ -137,7 +137,7 @@ class NewConsentGroup extends Component {
       .then(resp => {
         // TODO: window.location.href is a temporal way to redirect the user to project's consent-group page tab. We need to change this after
         // transitioning from old gsps style is solved.
-        window.location.href =  [this.props.serverURL, projectType, "show", this.props.projectKey, "?tab=consent-groups"].join("/");
+        window.location.href =  [this.props.serverURL, projectType, "show", this.props.projectKey, "?tab=consent-groups&new"].join("/");
         spinnerService.hideAll();
         this.setState(prev => {
           prev.formSubmitted = true;

--- a/src/main/webapp/consentGroup/NewConsentGroup.js
+++ b/src/main/webapp/consentGroup/NewConsentGroup.js
@@ -153,7 +153,7 @@ class NewConsentGroup extends Component {
           this.toggleSubmitError();
         });
     } else {
-      window.location.href = [this.props.serverURL, projectType, "show", this.props.projectKey, "?tab=consent-groups"].join("/");
+      window.location.href = [this.props.serverURL, projectType, "show", this.props.projectKey, "?tab=consent-groups&new"].join("/");
     }
   }
 

--- a/src/main/webapp/consentGroupReview/ConsentGroupReview.js
+++ b/src/main/webapp/consentGroupReview/ConsentGroupReview.js
@@ -1085,12 +1085,6 @@ class ConsentGroupReview extends Component {
           isRendered: this.state.readOnly === false
         }, ["Cancel"]),
 
-        // AlertMessage({
-        //   msg: 'Your Consent Group was successfully submitted to the Broad Institute’s Office of Research Subject Protection. It will now be reviewed by the ORSP team who will reach out to you if they have any questions.',
-        //   show: true,
-        //   type: 'success'
-        // }),
-        
         Panel({ title: "Consent Group Details" }, [
           InputFieldText({
             id: "inputConsentGroupName",

--- a/src/main/webapp/consentGroupReview/ConsentGroupReview.js
+++ b/src/main/webapp/consentGroupReview/ConsentGroupReview.js
@@ -1086,11 +1086,11 @@ class ConsentGroupReview extends Component {
         }, ["Cancel"]),
 
         AlertMessage({
-          msg: 'Your Consent Group was successfully submitted to the Broad Institute’s Office of Research Subject Protection.',
+          msg: 'Your Consent Group was successfully submitted to the Broad Institute’s Office of Research Subject Protection. It will now be reviewed by the ORSP team who will reach out to you if they have any questions.',
           show: true,
           type: 'success'
         }),
-
+        
         Panel({ title: "Consent Group Details" }, [
           InputFieldText({
             id: "inputConsentGroupName",

--- a/src/main/webapp/consentGroupReview/ConsentGroupReview.js
+++ b/src/main/webapp/consentGroupReview/ConsentGroupReview.js
@@ -1085,11 +1085,11 @@ class ConsentGroupReview extends Component {
           isRendered: this.state.readOnly === false
         }, ["Cancel"]),
 
-        AlertMessage({
-          msg: 'Your Consent Group was successfully submitted to the Broad Institute’s Office of Research Subject Protection. It will now be reviewed by the ORSP team who will reach out to you if they have any questions.',
-          show: true,
-          type: 'success'
-        }),
+        // AlertMessage({
+        //   msg: 'Your Consent Group was successfully submitted to the Broad Institute’s Office of Research Subject Protection. It will now be reviewed by the ORSP team who will reach out to you if they have any questions.',
+        //   show: true,
+        //   type: 'success'
+        // }),
         
         Panel({ title: "Consent Group Details" }, [
           InputFieldText({

--- a/src/main/webapp/consentGroupReview/ConsentGroupReview.js
+++ b/src/main/webapp/consentGroupReview/ConsentGroupReview.js
@@ -1120,6 +1120,7 @@ class ConsentGroupReview extends Component {
     let currentStartDate = this.state.current.consentExtraProps.startDate !== null ? format(new Date(this.state.current.consentExtraProps.startDate), 'MM/DD/YYYY') : null;
     return (
       div({}, [
+        h2({ className: "stepTitle" }, ["Consent Group: " + this.props.consentKey]),
         RequestClarificationDialog({
           closeModal: this.toggleState('requestClarification'),
           show: this.state.requestClarification,
@@ -1130,7 +1131,6 @@ class ConsentGroupReview extends Component {
           clarificationUrl: this.props.clarificationUrl,
           successClarification: this.successClarification
         }),
-        h2({ className: "stepTitle" }, ["Consent Group: " + this.props.consentKey]),
         ConfirmationDialog({
           closeModal: this.toggleState('approveDialog'),
           show: this.state.approveDialog,
@@ -1163,19 +1163,25 @@ class ConsentGroupReview extends Component {
           bodyText: 'Are you sure you want to remove this Consent Group?',
           actionLabel: 'Yes'
         }, []),
+
         button({
           className: "btn buttonPrimary floatRight",
           style: { 'marginTop': '15px' },
           onClick: this.enableEdit(),
           isRendered: this.state.readOnly === true
         }, ["Edit Information"]),
-
         button({
           className: "btn buttonSecondary floatRight",
           style: { 'marginTop': '15px' },
           onClick: this.cancelEdit(),
           isRendered: this.state.readOnly === false
         }, ["Cancel"]),
+
+        AlertMessage({
+          msg: 'Your Consent Group was successfully submitted to the Broad Institute’s Office of Research Subject Protection.',
+          show: true,
+          type: 'success'
+        }),
 
         Panel({ title: "Consent Group Details" }, [
           InputFieldText({
@@ -1636,12 +1642,14 @@ class ConsentGroupReview extends Component {
             disabled: this.state.disableApproveButton,
             isRendered: this.state.current.consentExtraProps.projectReviewApproved !== true && this.state.isAdmin && this.state.readOnly === true,
           }, ["Reject"]),
+
           /*visible for every user in readOnly mode and if there are changes to review*/
           button({
             className: "btn buttonSecondary floatRight",
             onClick: this.toggleState('discardEditsDialog'),
             isRendered: this.state.isAdmin && this.state.reviewSuggestion === true && this.state.readOnly === true
           }, ["Discard Edits"]),
+          
           button({
             className: "btn buttonSecondary floatRight",
             onClick: this.toggleState('requestClarification'),

--- a/src/main/webapp/project/NewProject.js
+++ b/src/main/webapp/project/NewProject.js
@@ -506,7 +506,7 @@ class NewProject extends Component {
       .then(resp => {
         // TODO: window.location.href is a temporal way to redirect the user to new project's review page tab. We need to change this after
         // transitioning from old gsps style is solved.
-        window.location.href =  [this.props.serverURL, projectType, "show", projectKey, "?tab=review"].join("/");
+        window.location.href =  [this.props.serverURL, projectType, "show", projectKey, "?tab=review?new"].join("/");
       }).catch(error => {
         spinnerService.hideAll();
         this.toggleTrueSubmitError();

--- a/src/main/webapp/project/NewProject.js
+++ b/src/main/webapp/project/NewProject.js
@@ -470,7 +470,7 @@ class NewProject extends Component {
           console.error(error);
         });
     } else {
-      window.location.href = [this.props.serverURL, projectType, "show", projectKey, "?tab=review"].join("/");
+      window.location.href = [this.props.serverURL, projectType, "show", projectKey, "?tab=review&new"].join("/");
     }
   }
 

--- a/src/main/webapp/project/NewProject.js
+++ b/src/main/webapp/project/NewProject.js
@@ -506,7 +506,7 @@ class NewProject extends Component {
       .then(resp => {
         // TODO: window.location.href is a temporal way to redirect the user to new project's review page tab. We need to change this after
         // transitioning from old gsps style is solved.
-        window.location.href =  [this.props.serverURL, projectType, "show", projectKey, "?tab=review?new"].join("/");
+        window.location.href =  [this.props.serverURL, projectType, "show", projectKey, "?tab=review&new"].join("/");
       }).catch(error => {
         spinnerService.hideAll();
         this.toggleTrueSubmitError();

--- a/src/main/webapp/projectReview/ProjectReview.js
+++ b/src/main/webapp/projectReview/ProjectReview.js
@@ -48,6 +48,8 @@ class ProjectReview extends Component {
       alertType: '',
       alertMessage: '',
       showAlert: false,
+      showSubmissionAlert: false,
+      showSuccessClarification: false,
       formData: {
         approvalStatus: '',
         description: '',
@@ -166,6 +168,9 @@ class ProjectReview extends Component {
   }
 
   componentDidMount() {
+    if (new URLSearchParams(window.location.search).has('new')) {
+      this.successNotification('showSubmissionAlert', 'Your Project was successfully submitted to the Broad Institute’s Office of Research Subject Protection. It will now be reviewed by the ORSP team who will reach out to you if they have any questions.');
+    }
     this.init();
   }
 
@@ -313,7 +318,7 @@ class ProjectReview extends Component {
   determinationHandler = (determination) => {
     let newValues = {};
     const answers = [];
-    this.clearAlertMessage();
+    this.clearAlertMessage('showAlert');
     determination.questions.forEach(question => {
 
       if (question.answer !== null) {
@@ -837,19 +842,19 @@ class ProjectReview extends Component {
     })
   };
 
-  successClarification = () => {
-    setTimeout(this.clearAlertMessage, 5000, null);
+  successNotification = (type, message) => {
+    setTimeout(this.clearAlertMessage(type), 5000, null);
     this.setState(prev => {
-      prev.showAlert = true;
-      prev.alertMessage = 'Request clarification sent.';
+      prev[type] = true;
+      prev.alertMessage = message;
       prev.alertType = 'success';
       return prev;
     });
   };
 
-  clearAlertMessage = () => {
+  clearAlertMessage = (type) => () => {
     this.setState(prev => {
-      prev.showAlert = false;
+      prev[type] = false;
       prev.alertMessage = '';
       prev.alertType = '';
       return prev;
@@ -1000,7 +1005,7 @@ class ProjectReview extends Component {
           emailUrl: this.props.emailUrl,
           userName: this.props.userName,
           clarificationUrl: this.props.clarificationUrl,
-          successClarification: this.successClarification
+          successClarification: this.successNotification
         }),
         
         button({
@@ -1025,7 +1030,7 @@ class ProjectReview extends Component {
 
         AlertMessage({
           msg: 'Your Project was successfully submitted to the Broad Institute’s Office of Research Subject Protection. It will now be reviewed by the ORSP team who will reach out to you if they have any questions.',
-          show: true,
+          show: this.state.showSubmissionAlert,
           // show: this.state.generalError || this.state.showAlert,
           type: 'success'
         }),
@@ -1381,7 +1386,7 @@ class ProjectReview extends Component {
         ]),
         AlertMessage({
           msg: this.state.alertMessage !== '' ? this.state.alertMessage : 'Please complete all required fields',
-          show: this.state.generalError || this.state.showAlert,
+          show: this.state.generalError || this.state.showAlert || this.state.showSuccessClarification,
           type: this.state.alertType !== '' ? this.state.alertType : 'danger'
         }),
         div({ className: "buttonContainer", style: { 'margin': '20px 0 40px 0' } }, [

--- a/src/main/webapp/projectReview/ProjectReview.js
+++ b/src/main/webapp/projectReview/ProjectReview.js
@@ -186,7 +186,7 @@ class ProjectReview extends Component {
                 return prev;
               });
             } else {
-              formData =  JSON.parse(currentStr);
+              formData = JSON.parse(currentStr);
               this.setState(prev => {
                 prev.formData = formData;
                 prev.current = current;
@@ -550,9 +550,9 @@ class ProjectReview extends Component {
     const field = e.target.name;
     const value = e.target.value;
     this.setState(prev => {
-        prev.formData[field] = value;
-        return prev;
-      },
+      prev.formData[field] = value;
+      return prev;
+    },
       () => {
         if (this.state.errorSubmit == true) this.isValid()
       });
@@ -560,9 +560,9 @@ class ProjectReview extends Component {
 
   handleProjectExtraPropsChangeRadio = (e, field, value) => {
     this.setState(prev => {
-        prev.formData.projectExtraProps[field] = value;
-        return prev;
-      },
+      prev.formData.projectExtraProps[field] = value;
+      return prev;
+    },
       () => {
         if (this.state.errorSubmit === true) this.isValid()
       });
@@ -572,9 +572,9 @@ class ProjectReview extends Component {
     const field = e.currentTarget.name;
     const value = e.currentTarget.value;
     this.setState(prev => {
-        prev.formData.projectExtraProps[field] = value;
-        return prev;
-      },
+      prev.formData.projectExtraProps[field] = value;
+      return prev;
+    },
       () => {
         if (this.state.errorSubmit === true) this.isValid()
       });
@@ -601,7 +601,7 @@ class ProjectReview extends Component {
 
   toggleState = (e) => () => {
     this.setState((state, props) => {
-      return { [e]: !state[e]}
+      return { [e]: !state[e] }
     });
   };
 
@@ -783,7 +783,7 @@ class ProjectReview extends Component {
       if (updatedForm[field] !== '' && value === undefined) {
         prev.formData.projectExtraProps[field] = updatedForm[field];
       } else if (value !== undefined) {
-        prev.formData.projectExtraProps[field] = value ;
+        prev.formData.projectExtraProps[field] = value;
       }
       prev.showInfoSecurityError = false;
       prev.generalError = false;
@@ -851,13 +851,19 @@ class ProjectReview extends Component {
           onClick: this.enableEdit(),
           isRendered: this.state.readOnly === true
         }, ["Edit Information"]),
-
         button({
           className: "btn buttonSecondary floatRight",
           style: { 'marginTop': '15px' },
           onClick: this.cancelEdit(),
           isRendered: this.state.readOnly === false
         }, ["Cancel"]),
+
+        AlertMessage({
+          msg: 'Your Project was successfully submitted to the Broad Institute’s Office of Research Subject Protection.',
+          show: true,
+          type: 'success'
+        }),
+
         Panel({ title: "Notes to ORSP", isRendered: this.state.readOnly === false || !isEmpty(this.state.formData.projectExtraProps.editDescription) }, [
           div({ isRendered: this.projectType === "IRB Project" }, [
             InputFieldRadio({
@@ -1014,8 +1020,8 @@ class ProjectReview extends Component {
             currentValue: this.state.current.projectExtraProps.uploadConsentGroup,
             optionValues: ["uploadNow", "uploadLater", "notUpload"],
             optionLabels: [
-              span({},["Yes, I will upload a Consent Group ", span({ className: "bold"}, ["now"]) ]),
-              span({},["Yes, I will upload a Consent Group ", span({ className: "bold"}, ["later"]) ]),
+              span({}, ["Yes, I will upload a Consent Group ", span({ className: "bold" }, ["now"])]),
+              span({}, ["Yes, I will upload a Consent Group ", span({ className: "bold" }, ["later"])]),
               "No, I will not upload a Consent Group"
             ],
             onChange: this.handleProjectExtraPropsChangeRadio,

--- a/src/main/webapp/projectReview/ProjectReview.js
+++ b/src/main/webapp/projectReview/ProjectReview.js
@@ -1061,7 +1061,6 @@ class ProjectReview extends Component {
         AlertMessage({
           msg: 'Your Project was successfully submitted to the Broad Institute’s Office of Research Subject Protection. It will now be reviewed by the ORSP team who will reach out to you if they have any questions.',
           show: this.state.showSubmissionAlert,
-          // show: this.state.generalError || this.state.showAlert,
           type: 'success'
         }),
 

--- a/src/main/webapp/projectReview/ProjectReview.js
+++ b/src/main/webapp/projectReview/ProjectReview.js
@@ -173,11 +173,8 @@ class ProjectReview extends Component {
     console.log(error, info);
   }
 
-  componentDidMount() {
+    componentDidMount() {
     this.init();
-    if (new URLSearchParams(window.location.search).has('new')) {
-      this.successNotification('showSubmissionAlert', 'Your Project was successfully submitted to the Broad Institute’s Office of Research Subject Protection. It will now be reviewed by the ORSP team who will reach out to you if they have any questions.', 8000);
-    }
   }
 
   init() {
@@ -224,6 +221,9 @@ class ProjectReview extends Component {
 
         Review.getSuggestions(this.props.serverURL, this.props.projectKey).then(
           data => {
+            if (new URLSearchParams(window.location.search).has('new')) {
+              this.successNotification('showSubmissionAlert', 'Your Project was successfully submitted to the Broad Institute’s Office of Research Subject Protection. It will now be reviewed by the ORSP team who will reach out to you if they have any questions.', 8000);
+            }
             if (data.data !== '') {
               formData = JSON.parse(data.data.suggestions);
 

--- a/src/main/webapp/projectReview/ProjectReview.js
+++ b/src/main/webapp/projectReview/ProjectReview.js
@@ -173,10 +173,10 @@ class ProjectReview extends Component {
   }
 
   componentDidMount() {
-    if (new URLSearchParams(window.location.search).has('new')) {
-      this.successNotification('showSubmissionAlert', 'Your Project was successfully submitted to the Broad Institute’s Office of Research Subject Protection. It will now be reviewed by the ORSP team who will reach out to you if they have any questions.');
-    }
     this.init();
+    if (new URLSearchParams(window.location.search).has('new')) {
+      this.successNotification('showSubmissionAlert', 'Your Project was successfully submitted to the Broad Institute’s Office of Research Subject Protection. It will now be reviewed by the ORSP team who will reach out to you if they have any questions.', 8000);
+    }
   }
 
   init() {
@@ -220,8 +220,6 @@ class ProjectReview extends Component {
             });
           }
         });
-
-
 
         Review.getSuggestions(this.props.serverURL, this.props.projectKey).then(
           data => {
@@ -867,8 +865,8 @@ class ProjectReview extends Component {
     })
   };
 
-  successNotification = (type, message) => {
-    setTimeout(this.clearAlertMessage(type), 5000, null);
+  successNotification = (type, message, time) => {
+    setTimeout(this.clearAlertMessage(type), time, null);
     this.setState(prev => {
       prev[type] = true;
       prev.alertMessage = message;

--- a/src/main/webapp/projectReview/ProjectReview.js
+++ b/src/main/webapp/projectReview/ProjectReview.js
@@ -1024,8 +1024,9 @@ class ProjectReview extends Component {
         }, ["Cancel"]),
 
         AlertMessage({
-          msg: 'Your Project was successfully submitted to the Broad Institute’s Office of Research Subject Protection.',
+          msg: 'Your Project was successfully submitted to the Broad Institute’s Office of Research Subject Protection. It will now be reviewed by the ORSP team who will reach out to you if they have any questions.',
           show: true,
+          // show: this.state.generalError || this.state.showAlert,
           type: 'success'
         }),
 


### PR DESCRIPTION
## Addresses
[BTRX-628](https://broadinstitute.atlassian.net/browse/BTRX-628): ORSP - Add feddback message after project/CG submission

## Changes
- Modify pre-existent temporizer method to accept as paramether time, message, and alert type to be re-used.

**Note:** The same functionality was added in gsp code, this should be temporal until "consent group" tab is migrated to react.

## Testing
- Create a new Project, after submission, a green alert message should be displayed at the top indicating the submission has been successfully made. This message should disapear after 8 seconds.
- The same behaviour as above should happen after a new consent group is created, but the message is displayed in Project's Consent Group tab. This message should disapear after 8 seconds.


---

- [x] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Get a thumb from @rushtong
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
