### PR TITLE
BTRX - 682 - Hotfix

### DIFF
--- a/grails-app/services/org/broadinstitute/orsp/QueryService.groovy
+++ b/grails-app/services/org/broadinstitute/orsp/QueryService.groovy
@@ -355,7 +355,7 @@ class QueryService implements Status {
         }
         Map<Long, List <StorageDocument>> storageDocuments = findAllDocumentsBySampleCollectionId(consentCollectionIds)
         consentCollectionLinkList.each {
-            sampleInfo.put(it, storageDocuments.get(it.id))
+            sampleInfo.put(it, storageDocuments.getOrDefault(it.id, []))
         }
         sampleInfo
     }


### PR DESCRIPTION
## Addresses
Hotfix for [PR-160](https://github.com/broadinstitute/orsp-pub/pull/160)
[BTRX-682](https://broadinstitute.atlassian.net/browse/BTRX-682)

## Changes
- When `findCollectionLinksByConsentKeyAndProjectKey()` gets each collectionLink's documents, and there are at least one without documents, it sets its collectionLink document as Null, which causes conflicts in the Ui. To fix this we used getOrDefault.

## Testing
- Associate a Sample Collection without any document uploaded to a Sample / Data cohort. Access to its linkInfo page and select that Sample Collection "Documents" tab.
---

- [x] **Submitter**: Verify all tests go green, including CI tests
- [x] **Submitter**: Get a thumb from Belatrix
- [x] **Submitter**: Get a thumb from @rushtong
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
