### PR TITLE
BTRX - 677 - Remove data cohorts status

### DIFF
--- a/grails-app/views/consentGroup/show.gsp
+++ b/grails-app/views/consentGroup/show.gsp
@@ -29,9 +29,7 @@
         </span>
     </g:if>
     <div class="issue-type">
-      <span>New Status:</span>
-      <span>${issue?.approvalStatus}</span>
-      <br/><span>Information Sub-Status:</span>
+      <span>Information Sub-Status:</span>
       <span>${projectReviewApproved ? 'Approved' : 'Pending'}</span>
       <br/><span>Documents Sub-Status:</span>
       <span>${attachmentsApproved ? 'Approved' : 'Pending'}</span>


### PR DESCRIPTION
## Addresses
[BTRX-677](https://broadinstitute.atlassian.net/browse/BTRX-677) : Review / Refactor Sample/Data Cohort approval process

## Changes
- Remove deprecated status from sample/data cohorts.

## Testing
- The header status "New Status" should not be visible anymore in Sample / Data cohorts.

---

- [x] **Submitter**: Verify all tests go green, including CI tests
- [x] **Submitter**: Get a thumb from Belatrix
- [x] **Submitter**: Get a thumb from @rushtong
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
