### PR TITLE
[BTRX-685] Select sample already associated

### DIFF
--- a/grails-app/views/layouts/main_component.gsp
+++ b/grails-app/views/layouts/main_component.gsp
@@ -114,7 +114,7 @@
         attachDocumentsURL: "${createLink(uri: '/api/files-helper/attach-document', method: 'POST')}",
         consentGroupUrl: "${createLink(controller: 'newConsentGroup', action: 'findByUUID')}",
         consentNamesSearchURL: "${createLink(controller: 'consentGroup', action: 'consentGroupSummaries')}",
-        getConsentGroups: "${createLink(controller: 'consentGroup', action: 'getConsentGroups')}",
+        consentGroupsUrl: "${createLink(controller: 'consentGroup', action: 'getConsentGroups')}",
         createConsentGroupURL: "${createLink(controller:'newConsentGroup', action: 'save', uri: '/api/consent-group', method: 'POST')}",
         createProjectURL: "${createLink(controller:'project', action: 'save', uri: '/api/project', method: 'POST')}",
         error: "${error}",
@@ -134,8 +134,8 @@
         serverURL: "${webRequest.baseUrl}",
         userNameSearchUrl: "${createLink(controller: 'search', action: 'getMatchingUsers')}",
         sourceDiseases: "${createLink(controller: 'search', action: 'getMatchingDiseaseOntologies')}",
-        unConsentedSampleCollections: "${createLink(controller: 'consentGroup', action: 'unConsentedSampleCollections')}",
-        getConsentGroupSampleCollections: "${createLink(controller: 'consentGroup', action: 'getConsentGroupSampleCollections')}",
+        unlinkedSampleCollectionsUrl: "${createLink(controller: 'consentGroup', action: 'unConsentedSampleCollections')}",
+        linkedSampleCollectionsUrl: "${createLink(controller: 'consentGroup', action: 'getConsentGroupSampleCollections')}",
       };
     </script>
 

--- a/grails-app/views/layouts/main_component.gsp
+++ b/grails-app/views/layouts/main_component.gsp
@@ -133,6 +133,8 @@
         serverURL: "${webRequest.baseUrl}",
         userNameSearchUrl: "${createLink(controller: 'search', action: 'getMatchingUsers')}",
         sourceDiseases: "${createLink(controller: 'search', action: 'getMatchingDiseaseOntologies')}",
+        unConsentedSampleCollections: "${createLink(controller: 'consentGroup', action: 'unConsentedSampleCollections')}",
+        getConsentGroupSampleCollections: "${createLink(controller: 'consentGroup', action: 'getConsentGroupSampleCollections')}",
       };
     </script>
 

--- a/src/main/webapp/components/InputFieldSelect.js
+++ b/src/main/webapp/components/InputFieldSelect.js
@@ -120,6 +120,7 @@ export const InputFieldSelect = hh(class InputFieldSelect extends Component {
               isMulti: this.props.isMulti,
               isClearable: this.props.isClearable,
               isLoading: isLoading,
+              defaultMenuIsOpen: true,
             })
           ])
         ])

--- a/src/main/webapp/components/InputFieldSelect.js
+++ b/src/main/webapp/components/InputFieldSelect.js
@@ -6,8 +6,8 @@ import './InputField.css';
 import get from 'lodash/get';
 
 const selectWithLabels = {
-  selectWithLabels: {
-    color:'#66666',
+  groupHeading: (provided, state) => ({
+    color:'#666666',
     cursor:'default',
     display: 'block',
     fontWeight: '500',
@@ -16,8 +16,8 @@ const selectWithLabels = {
     textTransform: 'uppercase',
     fontSize: '14px !important',
     borderBottom: '1px solid #DDDDDD',
-  }
-}
+  }),
+};
 
 export const InputFieldSelect = hh(class InputFieldSelect extends Component {
 
@@ -134,6 +134,7 @@ export const InputFieldSelect = hh(class InputFieldSelect extends Component {
               isMulti: this.props.isMulti,
               isClearable: this.props.isClearable,
               isLoading: isLoading,
+              styles: selectWithLabels,
               defaultMenuIsOpen: true,
             })
           ])

--- a/src/main/webapp/components/InputFieldSelect.js
+++ b/src/main/webapp/components/InputFieldSelect.js
@@ -58,6 +58,7 @@ export const InputFieldSelect = hh(class InputFieldSelect extends Component {
   };
 
   render() {
+    const { isLoading = false, placeholder = '' } = this.props;
     let edited = false;
     let currentValueStr;
     let currentValue;
@@ -118,7 +119,7 @@ export const InputFieldSelect = hh(class InputFieldSelect extends Component {
               isDisabled: this.props.readOnly,
               isMulti: this.props.isMulti,
               isClearable: this.props.isClearable,
-              isLoading: this.props.isLoading,
+              isLoading: isLoading,
             })
           ])
         ])

--- a/src/main/webapp/components/InputFieldSelect.js
+++ b/src/main/webapp/components/InputFieldSelect.js
@@ -135,7 +135,6 @@ export const InputFieldSelect = hh(class InputFieldSelect extends Component {
               isClearable: this.props.isClearable,
               isLoading: isLoading,
               styles: selectWithLabels,
-              defaultMenuIsOpen: true,
             })
           ])
         ])

--- a/src/main/webapp/components/InputFieldSelect.js
+++ b/src/main/webapp/components/InputFieldSelect.js
@@ -5,6 +5,20 @@ import { InputField } from './InputField';
 import './InputField.css';
 import get from 'lodash/get';
 
+const selectWithLabels = {
+  selectWithLabels: {
+    color:'#66666',
+    cursor:'default',
+    display: 'block',
+    fontWeight: '500',
+    marginBottom: '7px',
+    padding: '19px 12px 7px 12px',
+    textTransform: 'uppercase',
+    fontSize: '14px !important',
+    borderBottom: '1px solid #DDDDDD',
+  }
+}
+
 export const InputFieldSelect = hh(class InputFieldSelect extends Component {
 
   static getDerivedStateFromError(error) {

--- a/src/main/webapp/linkWizard/LinkQuestions.js
+++ b/src/main/webapp/linkWizard/LinkQuestions.js
@@ -66,7 +66,7 @@ export const LinkQuestions = hh(class LinkQuestions extends Component {
             step: 1,
             currentStep: this.props.currentStep,
             user: this.props.user,
-            searchUsersURL: this.props.searchUsersURL,
+            searchUsersURL: component.searchUsersURL,
             updateForm: this.props.updateInfoSecurityFormData,
             generalError: this.props.generalError,
             submitError: this.props.submitError,

--- a/src/main/webapp/linkWizard/LinkWizard.js
+++ b/src/main/webapp/linkWizard/LinkWizard.js
@@ -305,6 +305,7 @@ export const LinkWizard = hh( class LinkWizard extends Component {
     // if (field === "consentGroup") {
     //   this.getAllSampleCollections(updatedForm.key);
     // }
+    console.log('updatedForm', updatedForm, 'field', field);
     if (this.state.currentStep === 0) {
       this.validateLinkStep(field);
     }

--- a/src/main/webapp/linkWizard/LinkWizard.js
+++ b/src/main/webapp/linkWizard/LinkWizard.js
@@ -3,7 +3,7 @@ import { h1, hh } from 'react-hyperscript-helpers';
 import { Wizard } from "../components/Wizard";
 import { SelectSampleConsent } from "./SelectSampleConsent";
 import { LinkQuestions } from "./LinkQuestions";
-import { User, ConsentGroup, SampleCollections } from "../util/ajax";
+import { User } from "../util/ajax";
 import { isEmpty } from "../util/Utils";
 import { spinnerService } from '../util/spinner-service';
 import '../index.css';
@@ -53,8 +53,6 @@ export const LinkWizard = hh( class LinkWizard extends Component {
       showErrorInfoSecurity: false,
       isInfoSecurityValid: false,
       securityInfoFormData: {},
-      consentGroupIsLoading: false,
-      sampleCollectionIsLoading: false,
     }
   }
 
@@ -71,71 +69,7 @@ export const LinkWizard = hh( class LinkWizard extends Component {
 
   componentDidMount() {
     this.getUserSession();
-    this.getConsentGroups();
   }
-
-  getAllSampleCollections = (consentKey) => {
-    this.setState({ sampleCollectionIsLoading: true });
-
-    SampleCollections.getCollectionsCGLinked(this.props.getConsentGroupSampleCollections, consentKey).then(
-      resp => {
-        const sampleCollectionsList = [];
-        sampleCollectionsList.push({label: "Sample Collections Linked to " + consentKey, options: []});
-
-        sampleCollectionsList[0].options = resp.data.map(item => {
-          return {
-            key: item.id,
-            value: item.collectionId,
-            label: item.collectionId + ": " + item.name + " ( " + item.category + " )",
-          };
-        });
-
-        this.setState({
-          sampleCollectionList: sampleCollectionsList,
-          sampleCollectionIsLoading: false
-        })
-      }
-    );
-
-    SampleCollections.getSampleCollections(this.props.unConsentedSampleCollections, consentKey).then(
-      resp => {
-        const sampleCollectionsList = this.state.sampleCollectionList.splice(0);
-        sampleCollectionsList.push({label: "Link New Sample Collections to Sample Data/Cohort: " + consentKey, options: []});
-        sampleCollectionsList[1].options = resp.data.map(item => {
-          return {
-            key: item.id,
-            value: item.collectionId,
-            label: item.collectionId + ": " + item.name + " ( " + item.category + " )",
-          };
-        });
-
-        this.setState({
-          sampleCollectionList: sampleCollectionsList,
-          sampleCollectionIsLoading: false
-        })
-      }
-    );
-  };
-
-  getConsentGroups = () => {
-    this.setState({ consentGroupIsLoading: true });
-    ConsentGroup.getConsentGroupNames(this.props.getConsentGroups).then(
-      resp => {
-        const existingConsentGroups = resp.data.map(item => {
-          return {
-            key: item.id,
-            value: item.label,
-            label: item.label
-          }
-        });
-
-        this.setState({
-          existingConsentGroups: existingConsentGroups,
-          consentGroupIsLoading: false
-        });
-      }
-    );
-  };
 
   getUserSession() {
     User.getUserSession(this.props.getUserUrl).then(
@@ -368,9 +302,9 @@ export const LinkWizard = hh( class LinkWizard extends Component {
   }
 
   updateGeneralForm = (updatedForm, field) => {
-    if (field === "consentGroup") {
-      this.getAllSampleCollections(updatedForm.key);
-    }
+    // if (field === "consentGroup") {
+    //   this.getAllSampleCollections(updatedForm.key);
+    // }
     if (this.state.currentStep === 0) {
       this.validateLinkStep(field);
     }
@@ -408,12 +342,13 @@ export const LinkWizard = hh( class LinkWizard extends Component {
           fileHandler: this.fileHandler,
           files: this.state.files,
           currentStep: currentStep,
-          existingConsentGroups: this.state.existingConsentGroups,
           consentGroup: this.state.consentGroup,
           updateForm: this.updateGeneralForm,
           projectKeyLabel: this.props.projectKey,
           consentGroupIsLoading: this.state.consentGroupIsLoading,
-          sampleCollectionIsLoading: this.state.sampleCollectionIsLoading,
+          getConsentGroupSampleCollections: this.props.getConsentGroupSampleCollections,
+          getConsentGroups: this.props.getConsentGroups,
+          unConsentedSampleCollections: this.props.unConsentedSampleCollections,
         }),
         LinkQuestions({
           title: "Security/MTA/International Info",

--- a/src/main/webapp/linkWizard/LinkWizard.js
+++ b/src/main/webapp/linkWizard/LinkWizard.js
@@ -302,10 +302,6 @@ export const LinkWizard = hh( class LinkWizard extends Component {
   }
 
   updateGeneralForm = (updatedForm, field) => {
-    // if (field === "consentGroup") {
-    //   this.getAllSampleCollections(updatedForm.key);
-    // }
-    console.log('updatedForm', updatedForm, 'field', field);
     if (this.state.currentStep === 0) {
       this.validateLinkStep(field);
     }

--- a/src/main/webapp/linkWizard/LinkWizard.js
+++ b/src/main/webapp/linkWizard/LinkWizard.js
@@ -72,7 +72,7 @@ export const LinkWizard = hh( class LinkWizard extends Component {
   }
 
   getUserSession() {
-    User.getUserSession(this.props.getUserUrl).then(
+    User.getUserSession(component.getUserUrl).then(
       resp => this.setState({ user: resp.data })
     ).catch(error => {
       this.setState(() => { throw error; });
@@ -178,7 +178,7 @@ export const LinkWizard = hh( class LinkWizard extends Component {
     consentCollectionLink.consentKey = this.state.consentGroup.key;
     // consent collection link info
     consentCollectionLink.sampleCollectionId = this.state.sampleCollection.value;
-    consentCollectionLink.projectKey = this.props.projectKey;
+    consentCollectionLink.projectKey = component.projectKey;
     consentCollectionLink.requireMta = this.state.linkFormData.requireMta;
     // security
     consentCollectionLink.pii = this.state.securityInfoFormData.pii == "true" ? true : false;
@@ -206,14 +206,14 @@ export const LinkWizard = hh( class LinkWizard extends Component {
     spinnerService.showAll();
 
     if (this.validateForm()) {
-      let projectType = await Project.getProjectType(this.props.serverURL, this.props.projectKey);
+      let projectType = await Project.getProjectType(component.serverURL, component.projectKey);
 
       this.removeErrorMessage();
       this.changeSubmitState();
       const documents = this.state.files;
       const consentCollectionData = this.getConsentCollectionData();
-      ConsentCollectionLink.create(this.props.serverURL, consentCollectionData, documents).then(resp => {
-        window.location.href  = [this.props.serverURL, projectType, "show", this.props.projectKey, "?tab=consent-groups"].join("/");
+      ConsentCollectionLink.create(component.serverURL, consentCollectionData, documents).then(resp => {
+        window.location.href  = [component.serverURL, projectType, "show", component.projectKey, "?tab=consent-groups"].join("/");
       }).catch(error => {
         console.error(error);
         spinnerService.hideAll();
@@ -323,12 +323,11 @@ export const LinkWizard = hh( class LinkWizard extends Component {
         submitHandler: this.submitLink,
         showSubmit: this.showSubmit,
         disabledSubmit: this.state.formSubmitted,
-        loadingImage: this.props.loadingImage,
+        loadingImage: component.loadingImage,
       }, [
         SelectSampleConsent({
           title: "Sample/Data Cohort Info",
-          consentNamesSearchURL: this.props.consentNamesSearchURL,
-          sampleSearchUrl: this.props.sampleSearchUrl,
+          consentNamesSearchURL: component.consentNamesSearchURL,
           removeErrorMessage: this.removeErrorMessage,
           sampleCollectionList: this.state.sampleCollectionList,
           sampleCollection: this.state.sampleCollection,
@@ -338,11 +337,7 @@ export const LinkWizard = hh( class LinkWizard extends Component {
           currentStep: currentStep,
           consentGroup: this.state.consentGroup,
           updateForm: this.updateGeneralForm,
-          projectKeyLabel: this.props.projectKey,
           consentGroupIsLoading: this.state.consentGroupIsLoading,
-          getConsentGroupSampleCollections: this.props.getConsentGroupSampleCollections,
-          getConsentGroups: this.props.getConsentGroups,
-          unConsentedSampleCollections: this.props.unConsentedSampleCollections,
         }),
         LinkQuestions({
           title: "Security/MTA/International Info",
@@ -354,7 +349,6 @@ export const LinkWizard = hh( class LinkWizard extends Component {
           requireMta: this.state.linkFormData.requireMta,
           errors: this.state.errors,
           user: this.state.user,
-          searchUsersURL: this.props.searchUsersURL,
           updateInfoSecurityFormData: this.updateInfoSecurityFormData,
           showErrorInfoSecurity: this.state.showErrorInfoSecurity,
           generalError: this.state.generalError,

--- a/src/main/webapp/linkWizard/SelectSampleConsent.js
+++ b/src/main/webapp/linkWizard/SelectSampleConsent.js
@@ -63,10 +63,8 @@ export const SelectSampleConsent = hh(class SelectSampleConsent extends Componen
   };
 
   handleConsentGroupChange = (values) => (data) => {
-    console.log(data);
     this.getAllSampleCollections(data.key);
     this.setState(prev => {
-      console.log('DATA', data);
       prev.consentGroup = data;
       return prev;
     }, () => this.props.updateForm(this.state.consentGroup, "consentGroup"));
@@ -137,8 +135,7 @@ export const SelectSampleConsent = hh(class SelectSampleConsent extends Componen
           existingConsentGroups: existingConsentGroups,
           consentGroupIsLoading: false,
           consentGroup: existingConsentGroups[0]
-        });
-        this.handleConsentGroupChange(existingConsentGroups[0].key);
+        }, () => this.props.updateForm(this.state.consentGroup, "consentGroup"));
         this.getAllSampleCollections(existingConsentGroups[0].key);
       }
     );

--- a/src/main/webapp/linkWizard/SelectSampleConsent.js
+++ b/src/main/webapp/linkWizard/SelectSampleConsent.js
@@ -116,7 +116,7 @@ export const SelectSampleConsent = hh(class SelectSampleConsent extends Componen
 
   getConsentGroups = () => {
     this.setState({ consentGroupIsLoading: true });
-    ConsentGroup.getConsentGroupNames(this.props.getConsentGroups).then(
+    ConsentGroup.getConsentGroupNames(component.consentGroupsUrl).then(
       resp => {
         const existingConsentGroups = resp.data.map(item => {
           return {
@@ -139,7 +139,7 @@ export const SelectSampleConsent = hh(class SelectSampleConsent extends Componen
   getAllSampleCollections = (consentKey) => {
     this.setState({ sampleCollectionIsLoading: true });
 
-    SampleCollections.getCollectionsCGLinked(this.props.getConsentGroupSampleCollections, consentKey).then(
+    SampleCollections.getCollectionsCGLinked(component.linkedSampleCollectionsUrl, consentKey).then(
       resp => {
         const sampleCollectionList = [];
         sampleCollectionList.push({label: "Sample Collections Linked to " + consentKey, options: []});
@@ -159,7 +159,7 @@ export const SelectSampleConsent = hh(class SelectSampleConsent extends Componen
       }
     );
 
-    SampleCollections.getSampleCollections(this.props.unConsentedSampleCollections, consentKey).then(
+    SampleCollections.getSampleCollections(component.unlinkedSampleCollectionsUrl, consentKey).then(
       resp => {
         const sampleCollectionList = this.state.sampleCollectionList.splice(0);
         sampleCollectionList.push({label: "Link New Sample Collections to Sample Data/Cohort: " + consentKey, options: []});
@@ -213,7 +213,7 @@ export const SelectSampleConsent = hh(class SelectSampleConsent extends Componen
         }, [
           InputFieldSelect({
             id: "sampleCollection_select",
-            label: "Link Sample Collection to " + this.props.projectKeyLabel,
+            label: "Link Sample Collection to " + component.projectKey,
             isDisabled: false,
             options: this.state.sampleCollectionList,
             onChange: this.handleSampleCollectionChange,

--- a/src/main/webapp/linkWizard/SelectSampleConsent.js
+++ b/src/main/webapp/linkWizard/SelectSampleConsent.js
@@ -158,7 +158,6 @@ export const SelectSampleConsent = hh(class SelectSampleConsent extends Componen
             isMulti: false,
             edit: false,
             isLoading: this.props.sampleCollectionIsLoading,
-            styles: this.stylesSelect,
           }),
         ]),
         Panel({

--- a/src/main/webapp/linkWizard/SelectSampleConsent.js
+++ b/src/main/webapp/linkWizard/SelectSampleConsent.js
@@ -62,9 +62,11 @@ export const SelectSampleConsent = hh(class SelectSampleConsent extends Componen
     this.props.removeErrorMessage();
   };
 
-  handleConsentGroupChange = () => (data) => {
+  handleConsentGroupChange = (values) => (data) => {
+    console.log(data);
     this.getAllSampleCollections(data.key);
     this.setState(prev => {
+      console.log('DATA', data);
       prev.consentGroup = data;
       return prev;
     }, () => this.props.updateForm(this.state.consentGroup, "consentGroup"));
@@ -136,6 +138,7 @@ export const SelectSampleConsent = hh(class SelectSampleConsent extends Componen
           consentGroupIsLoading: false,
           consentGroup: existingConsentGroups[0]
         });
+        this.handleConsentGroupChange(existingConsentGroups[0].key);
         this.getAllSampleCollections(existingConsentGroups[0].key);
       }
     );
@@ -227,6 +230,7 @@ export const SelectSampleConsent = hh(class SelectSampleConsent extends Componen
             isMulti: false,
             edit: false,
             isLoading: this.state.sampleCollectionIsLoading,
+
           }),
         ]),
         Panel({

--- a/src/main/webapp/linkWizard/SelectSampleConsent.js
+++ b/src/main/webapp/linkWizard/SelectSampleConsent.js
@@ -158,6 +158,7 @@ export const SelectSampleConsent = hh(class SelectSampleConsent extends Componen
             isMulti: false,
             edit: false,
             isLoading: this.props.sampleCollectionIsLoading,
+            styles: this.stylesSelect,
           }),
         ]),
         Panel({

--- a/src/main/webapp/linkWizard/SelectSampleConsent.js
+++ b/src/main/webapp/linkWizard/SelectSampleConsent.js
@@ -141,16 +141,8 @@ export const SelectSampleConsent = hh(class SelectSampleConsent extends Componen
 
     SampleCollections.getCollectionsCGLinked(component.linkedSampleCollectionsUrl, consentKey).then(
       resp => {
-        const sampleCollectionList = [];
-        sampleCollectionList.push({label: "Sample Collections Linked to " + consentKey, options: []});
-
-        sampleCollectionList[0].options = resp.data.map(item => {
-          return {
-            key: item.id,
-            value: item.collectionId,
-            label: item.collectionId + ": " + item.name + " ( " + item.category + " )",
-          };
-        });
+        const label = "Sample Collections Linked to ";
+        const sampleCollectionList = this.setOptionsValues(resp.data, consentKey, label);
 
         this.setState({
           sampleCollectionList: sampleCollectionList,
@@ -161,15 +153,9 @@ export const SelectSampleConsent = hh(class SelectSampleConsent extends Componen
 
     SampleCollections.getSampleCollections(component.unlinkedSampleCollectionsUrl, consentKey).then(
       resp => {
-        const sampleCollectionList = this.state.sampleCollectionList.splice(0);
-        sampleCollectionList.push({label: "Link New Sample Collections to Sample Data/Cohort: " + consentKey, options: []});
-        sampleCollectionList[1].options = resp.data.map(item => {
-          return {
-            key: item.id,
-            value: item.collectionId,
-            label: item.collectionId + ": " + item.name + " ( " + item.category + " )",
-          };
-        });
+
+        const label = "Link New Sample Collections to Sample Data/Cohort: ";
+        const sampleCollectionList = this.setOptionsValues(resp.data, consentKey, label);
 
         this.setState({
           sampleCollectionList: sampleCollectionList,
@@ -177,6 +163,28 @@ export const SelectSampleConsent = hh(class SelectSampleConsent extends Componen
         })
       }
     );
+  };
+
+  setOptionsValues = (items, consentKey, label) => {
+    let sampleCollectionList = [];
+    let index = 0;
+
+    if (this.state.sampleCollectionList.length === 1) {
+      index = 1;
+      sampleCollectionList = this.state.sampleCollectionList.splice(0);
+    }
+
+    sampleCollectionList.push({label: label + consentKey, options: []});
+
+    sampleCollectionList[index].options = items.map(item => {
+      return {
+        key: item.id,
+        value: item.collectionId,
+        label: item.collectionId + ": " + item.name + " ( " + item.category + " )",
+      };
+    });
+
+    return sampleCollectionList;
   };
 
   render() {

--- a/src/main/webapp/linkWizard/index.js
+++ b/src/main/webapp/linkWizard/index.js
@@ -6,17 +6,7 @@ import ErrorHandler from '../components/ErrorHandler';
 
 ReactDOM.render(
   <ErrorHandler>
-    <LinkWizard
-      loadingImage = {component.loadingImage}
-      consentNamesSearchURL = {component.consentNamesSearchURL}
-      sampleSearchUrl = {component.sampleSearchUrl}
-      getConsentGroups = {component.getConsentGroups}
-      serverURL = {component.serverURL}
-      getUserUrl = {component.getUserUrl}
-      projectKey = {component.projectKey}
-      unConsentedSampleCollections = {component.unConsentedSampleCollections}
-      getConsentGroupSampleCollections = {component.getConsentGroupSampleCollections}
-    />
+    <LinkWizard />
   </ErrorHandler>,
   document.getElementById('linkWizard')
 );

--- a/src/main/webapp/linkWizard/index.js
+++ b/src/main/webapp/linkWizard/index.js
@@ -12,6 +12,8 @@ ReactDOM.render(
     serverURL = {component.serverURL}
     getUserUrl = {component.getUserUrl}
     projectKey = {component.projectKey}
+    unConsentedSampleCollections = {component.unConsentedSampleCollections}
+    getConsentGroupSampleCollections = {component.getConsentGroupSampleCollections}
   />,
   document.getElementById('linkWizard')
 );

--- a/src/main/webapp/util/ajax.js
+++ b/src/main/webapp/util/ajax.js
@@ -13,6 +13,10 @@ export const SampleCollections = {
 
   getSampleCollections(url, query) {
     return axios.get(url + '?term=' + query);
+  },
+
+  getCollectionsCGLinked(url, consentKey) {
+    return axios.get(url + '?consentKey=' + consentKey);
   }
 };
 


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/BTRX-685

## Changes
The Sample Collection select component now show a heading for the already linked SC, and another heading for the non linked SC.

## Testing
Describe for the reviewer how to test the specifics of this PR, both positive and negative cases. Also both selects now displays a loading indicator.

---

- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Get a thumb from Belatrix
- [ ] **Submitter**: Get a thumb from @rushtong
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
