### PR TITLE
Btrx 705 improve sample collection

### DIFF
--- a/src/main/webapp/components/Table.js
+++ b/src/main/webapp/components/Table.js
@@ -8,6 +8,18 @@ import { Btn } from './Btn';
 import './Table.css';
 import { handleRedirectToProject } from "../util/Utils";
 
+const styles = { 
+  statusWidth: '140',
+  fileTypeWidth: '170',
+  docVersionWidth: '90',
+  creatorWidth: '130',
+  infoLinkWidth: '96',
+  creationDateWidth: '140',
+  removeWidth: '45',
+  unlinkSampleCollectionWidth: '80',
+  collectionNameWidth: '270'
+}
+
 export const Table = hh(class Table extends Component {
 
   constructor(props) {
@@ -159,28 +171,28 @@ export const Table = hh(class Table extends Component {
                 dataField={header.value}
                 dataFormat={this.formatStatusColumn}
                 dataSort={true}
-                width={'140px'}>{header.name}</TableHeaderColumn>
+                width={styles.statusWidth}>{header.name}</TableHeaderColumn>
             } else if (header.value === 'fileType') {
               return <TableHeaderColumn 
                 isKey={isKey}
                 key={header.name}
                 dataField={header.value}
                 dataSort={true}
-                width={'170px'}>{header.name}</TableHeaderColumn>
+                width={styles.fileTypeWidth}>{header.name}</TableHeaderColumn>
             } else if (header.value === 'docVersion') {
               return <TableHeaderColumn 
                 isKey={isKey}
                 key={header.name}
                 dataField={header.value}
                 dataSort={true}
-                width={'90px'}>{header.name}</TableHeaderColumn>
+                width={styles.docVersionWidth}>{header.name}</TableHeaderColumn>
             } else if (header.value === 'creator') {
               return <TableHeaderColumn 
                 isKey={isKey}
                 key={header.name}
                 dataField={header.value}
                 dataSort={true}
-                width={'130px'}>{header.name}</TableHeaderColumn>
+                width={styles.creatorWidth}>{header.name}</TableHeaderColumn>
             } else if (header.value === 'fileName') {
               return <TableHeaderColumn key={header.name}
                 dataField={header.value}
@@ -204,26 +216,26 @@ export const Table = hh(class Table extends Component {
                 dataField={header.value}
                 dataFormat={this.redirectToInfoLink}
                 dataSort={ true }
-                width={'96px'}>{header.name}</TableHeaderColumn>
+                width={styles.infoLinkWidth}>{header.name}</TableHeaderColumn>
             } else if (header.value === 'creationDate') {
               return <TableHeaderColumn isKey={isKey}
                 key={header.name}
                 dataField={header.value}
                 dataFormat={this.parseDate}
                 dataSort={ true }
-                width={'140px'}>{header.name}</TableHeaderColumn>
+                width={styles.creationDateWidth}>{header.name}</TableHeaderColumn>
             } else if (header.value === 'remove') {
               return <TableHeaderColumn isKey={isKey}
                 dataField={header.value}
                 key={header.value}
                 dataFormat={this.formatRemoveBtn}
-                width={'45px'}>{header.name}</TableHeaderColumn>
+                width={styles.removeWidth}>{header.name}</TableHeaderColumn>
             } else if (header.value === 'unlinkSampleCollection') {
               return <TableHeaderColumn isKey={isKey}
                 key={index.toString()}
                 dataField={header.value}
                 dataFormat={this.unlinkSampleCollectionButton}
-                width={'80px'}>{"Unlink"}</TableHeaderColumn>
+                width={styles.unlinkSampleCollectionWidth}>{"Unlink"}</TableHeaderColumn>
             } else if (header.value === 'linkedProjectKey') {
               return <TableHeaderColumn isKey= {isKey}
                 key={header.name}
@@ -235,7 +247,7 @@ export const Table = hh(class Table extends Component {
                 dataField={header.value}
                 dataFormat={this.formatTooltip}
                 key={header.value}
-                width={'270px'}>{header.name}</TableHeaderColumn>
+                width={styles.collectionNameWidth}>{header.name}</TableHeaderColumn>
             } else {
               return <TableHeaderColumn isKey={isKey}
                 key={header.name}

--- a/src/main/webapp/components/Table.js
+++ b/src/main/webapp/components/Table.js
@@ -1,7 +1,7 @@
 import { Component } from 'react';
 import React from 'react';
 import { format } from 'date-fns';
-import { a, hh, button, span } from 'react-hyperscript-helpers';
+import { a, hh, button, td, span } from 'react-hyperscript-helpers';
 import { BootstrapTable, TableHeaderColumn } from 'react-bootstrap-table';
 import { DropdownButton, MenuItem, ButtonToolbar } from 'react-bootstrap';
 import { Btn } from './Btn';
@@ -46,6 +46,15 @@ export const Table = hh(class Table extends Component {
       </ButtonToolbar>
     );
 
+  };
+
+  formatTooltip = (cell, row) => {
+    console.log('row ahre', row);
+    return span ({
+      title: row.collectionName
+    },
+    [row.collectionName]
+    );
   };
 
   actionApprove = (uuid) => {
@@ -172,7 +181,8 @@ export const Table = hh(class Table extends Component {
                 key={header.name}
                 dataField={header.value}
                 dataFormat={this.redirectToInfoLink}
-                dataSort={ true }>{header.name}</TableHeaderColumn>
+                dataSort={ true }
+                width={'96px'}>{header.name}</TableHeaderColumn>
             } else if (header.value === 'creationDate') {
               return <TableHeaderColumn isKey={isKey}
                 key={header.name}
@@ -189,13 +199,20 @@ export const Table = hh(class Table extends Component {
               return <TableHeaderColumn isKey={isKey}
                 key={index.toString()}
                 dataField={header.value}
-                dataFormat={this.unlinkSampleCollectionButton}>{"Unlink"}</TableHeaderColumn>
+                dataFormat={this.unlinkSampleCollectionButton}
+                width={'80px'}>{"Unlink"}</TableHeaderColumn>
             } else if (header.value === 'linkedProjectKey') {
               return <TableHeaderColumn isKey= {isKey}
                 key={header.name}
                 dataField={header.value}
                 dataFormat={this.redirectToSampleCollectionLinkedProject}
                 dataSort={ true }>{header.name}</TableHeaderColumn>
+            } else if (header.value==='collectionName') {
+                return <TableHeaderColumn isKey={isKey}
+                dataField={header.value}
+                dataFormat={this.formatTooltip}
+                key={header.value}
+                width={'270px'}>{header.name}</TableHeaderColumn>
             } else {
               return <TableHeaderColumn isKey={isKey}
                 key={header.name}

--- a/src/main/webapp/components/Table.js
+++ b/src/main/webapp/components/Table.js
@@ -166,7 +166,7 @@ export const Table = hh(class Table extends Component {
                 key={header.name}
                 dataField={header.value}
                 dataSort={true}
-                width={'150px'}>{header.name}</TableHeaderColumn>
+                width={'170px'}>{header.name}</TableHeaderColumn>
             } else if (header.value === 'docVersion') {
               return <TableHeaderColumn 
                 isKey={isKey}

--- a/src/main/webapp/components/Table.js
+++ b/src/main/webapp/components/Table.js
@@ -49,7 +49,6 @@ export const Table = hh(class Table extends Component {
   };
 
   formatTooltip = (cell, row) => {
-    console.log('row ahre', row);
     return span ({
       title: row.collectionName
     },
@@ -69,7 +68,8 @@ export const Table = hh(class Table extends Component {
     if (this.props.reviewFlow) {
       return a({
         href: `${this.props.downloadDocumentUrl}?uuid=${row.uuid}`,
-        target: '_blank'
+        target: '_blank',
+        title: row.fileName,
       }, [row.fileName])
     } else {
       return span({}, [row.fileName])
@@ -158,7 +158,29 @@ export const Table = hh(class Table extends Component {
               return <TableHeaderColumn key={header.name}
                 dataField={header.value}
                 dataFormat={this.formatStatusColumn}
-                dataSort={true}>{header.name}</TableHeaderColumn>
+                dataSort={true}
+                width={'140px'}>{header.name}</TableHeaderColumn>
+            } else if (header.value === 'fileType') {
+              return <TableHeaderColumn 
+                isKey={isKey}
+                key={header.name}
+                dataField={header.value}
+                dataSort={true}
+                width={'150px'}>{header.name}</TableHeaderColumn>
+            } else if (header.value === 'docVersion') {
+              return <TableHeaderColumn 
+                isKey={isKey}
+                key={header.name}
+                dataField={header.value}
+                dataSort={true}
+                width={'90px'}>{header.name}</TableHeaderColumn>
+            } else if (header.value === 'creator') {
+              return <TableHeaderColumn 
+                isKey={isKey}
+                key={header.name}
+                dataField={header.value}
+                dataSort={true}
+                width={'130px'}>{header.name}</TableHeaderColumn>
             } else if (header.value === 'fileName') {
               return <TableHeaderColumn key={header.name}
                 dataField={header.value}
@@ -188,7 +210,8 @@ export const Table = hh(class Table extends Component {
                 key={header.name}
                 dataField={header.value}
                 dataFormat={this.parseDate}
-                dataSort={ true }>{header.name}</TableHeaderColumn>
+                dataSort={ true }
+                width={'140px'}>{header.name}</TableHeaderColumn>
             } else if (header.value === 'remove') {
               return <TableHeaderColumn isKey={isKey}
                 dataField={header.value}

--- a/src/main/webapp/consentGroupReview/ConsentGroupReview.js
+++ b/src/main/webapp/consentGroupReview/ConsentGroupReview.js
@@ -932,18 +932,16 @@ class ConsentGroupReview extends Component {
         ]),
 
         Panel({ title: "Sample Collections" }, [
-          div({ className: "fixed-columns" }, [
-            Table({
-              headers: headers,
-              isAdmin: this.state.isAdmin,
-              data: this.state.current.sampleCollectionLinks,
-              handleRedirectToInfoLink: this.handleRedirectToInfoLink,
-              serverURL: this.props.serverURL,
-              unlinkSampleCollection: this.toggleUnlinkDialog,
-              sizePerPage: 10,
-              paginationSize: 10
-            })
-          ])
+          Table({
+            headers: headers,
+            isAdmin: this.state.isAdmin,
+            data: this.state.current.sampleCollectionLinks,
+            handleRedirectToInfoLink: this.handleRedirectToInfoLink,
+            serverURL: this.props.serverURL,
+            unlinkSampleCollection: this.toggleUnlinkDialog,
+            sizePerPage: 10,
+            paginationSize: 10
+          })
         ]),
 
         Panel({ title: "Sample Collection Date Range" }, [

--- a/src/main/webapp/consentGroupReview/ConsentGroupReview.js
+++ b/src/main/webapp/consentGroupReview/ConsentGroupReview.js
@@ -932,16 +932,18 @@ class ConsentGroupReview extends Component {
         ]),
 
         Panel({ title: "Sample Collections" }, [
-          Table({
-            headers: headers,
-            isAdmin: this.state.isAdmin,
-            data: this.state.current.sampleCollectionLinks,
-            handleRedirectToInfoLink: this.handleRedirectToInfoLink,
-            serverURL: this.props.serverURL,
-            unlinkSampleCollection: this.toggleUnlinkDialog,
-            sizePerPage: 10,
-            paginationSize: 10
-          })
+          div({ className: "fixed-columns" }, [
+            Table({
+              headers: headers,
+              isAdmin: this.state.isAdmin,
+              data: this.state.current.sampleCollectionLinks,
+              handleRedirectToInfoLink: this.handleRedirectToInfoLink,
+              serverURL: this.props.serverURL,
+              unlinkSampleCollection: this.toggleUnlinkDialog,
+              sizePerPage: 10,
+              paginationSize: 10
+            })
+          ])
         ]),
 
         Panel({ title: "Sample Collection Date Range" }, [


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/BTRX-705

## Changes
- Link names and urls are fully displayed when you mouseover in a link (tooltip/title)
- Column width size is improved depending on the column content, assigning more width to columns with larger strings

## Testing
- Sample Collection Table
- Project > Documents Tab 
- Consent Group

---

- [x] **Submitter**: Verify all tests go green, including CI tests
- [x] **Submitter**: Get a thumb from Belatrix
- [x] **Submitter**: Get a thumb from @rushtong
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
