### PR TITLE
Remove Top Nav Options and Project Question

### DIFF
--- a/grails-app/views/base/_topNav.gsp
+++ b/grails-app/views/base/_topNav.gsp
@@ -26,10 +26,6 @@
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown">New <b class="caret"></b></a>
                         <ul class="dropdown-menu">
                             <li><a href="${createLink(controller: 'project', action: 'pages')}">New Project</a></li>
-                            <li><a href="${createLink(controller: 'irb', action: 'create')}">IRB Protocol Record</a></li>
-                            <li><a href="${createLink(controller: 'ne', action: 'create')}">'Not Engaged' Project</a></li>
-                            <li><a href="${createLink(controller: 'nhsr', action: 'create')}">Not Human Subjects Research Project</a></li>
-                            <li><a href="${createLink(controller: 'consentGroup', action: 'create')}">Consent Group</a></li>
                         </ul>
                     </li>
                     </auth:isNotViewer>

--- a/src/main/webapp/project/NewProject.js
+++ b/src/main/webapp/project/NewProject.js
@@ -45,7 +45,6 @@ class NewProject extends Component {
       errors: {
         studyDescription: false,
         pTitle: false,
-        subjectProtection: false,
         fundings: false,
         attestation: false,
         fundingAwardNumber: false
@@ -147,7 +146,6 @@ class NewProject extends Component {
     extraProperties.push({name: 'projectTitle', value: this.state.generalDataFormData.pTitle !== '' ? this.state.generalDataFormData.pTitle : null});
     extraProperties.push({name: 'protocol', value: this.state.generalDataFormData.irbProtocolId !== '' ? this.state.generalDataFormData.irbProtocolId : null});
     extraProperties.push({name: 'notCGSpecify', value: this.state.generalDataFormData.notCGSpecify !== '' ? this.state.generalDataFormData.notCGSpecify : null});
-    extraProperties.push({name: 'subjectProtection', value: this.state.generalDataFormData.subjectProtection !== '' ? this.state.generalDataFormData.subjectProtection : null});
     extraProperties.push({name: 'attestation', value: this.state.attestationFormData.attestation !== '' ? this.state.attestationFormData.attestation : null});
     extraProperties.push({name: 'irbReferral', value: isEmpty(this.state.generalDataFormData.irbReferral.value) ? null : JSON.stringify(this.state.generalDataFormData.irbReferral)});
     extraProperties.push({name: 'projectAvailability', value: 'available'});
@@ -268,17 +266,12 @@ class NewProject extends Component {
   validateGeneralData(field) {
     let studyDescription = false;
     let pTitle = false;
-    let subjectProtection = false;
     let isValid = true;
     let fundings = false;
     let fundingAwardNumber = false;
 
     if (isEmpty(this.state.generalDataFormData.studyDescription)) {
       studyDescription = true;
-      isValid = false;
-    }
-    if (this.state.generalDataFormData.subjectProtection === undefined || this.state.generalDataFormData.subjectProtection === '') {
-      subjectProtection = true;
       isValid = false;
     }
     if (isEmpty(this.state.generalDataFormData.pTitle)) {
@@ -303,15 +296,13 @@ class NewProject extends Component {
     if (field === undefined || field === null || field === 0) {
       this.setState(prev => {
         prev.errors.studyDescription = studyDescription;
-        prev.errors.subjectProtection = subjectProtection;
         prev.errors.pTitle = pTitle;
         prev.errors.fundings = fundings;
         prev.errors.fundingAwardNumber = fundingAwardNumber;
         return prev;
       });
     }
-    else if (field === 'fundings' || field === 'studyDescription' ||
-       field === 'subjectProtection' || field === 'pTitle') {
+    else if (field === 'fundings' || field === 'studyDescription' || field === 'pTitle') {
 
       this.setState(prev => {
         if (field === 'fundings') {
@@ -320,9 +311,6 @@ class NewProject extends Component {
         }
         else if (field === 'studyDescription') {
           prev.errors.studyDescription = studyDescription;
-        }
-        else if (field === 'subjectProtection') {
-          prev.errors.subjectProtection = subjectProtection;
         }
         else if (field === 'pTitle') {
           prev.errors.pTitle = pTitle;

--- a/src/main/webapp/project/NewProjectGeneralData.js
+++ b/src/main/webapp/project/NewProjectGeneralData.js
@@ -38,7 +38,6 @@ export const NewProjectGeneralData = hh(class NewProjectGeneralData extends Comp
         studyDescription: '',
         pTitle: '',
         irbProtocolId: '',
-        subjectProtection: '',
         irbReferral: '',
         fundings: [{ source: '', sponsor: '', identifier: '' }],
         collaborators: []
@@ -51,7 +50,6 @@ export const NewProjectGeneralData = hh(class NewProjectGeneralData extends Comp
         studyDescription: '',
         pTitle: '',
         irbProtocolId: '',
-        subjectProtection: '',
         irbReferral: '',
         fundings: [{ source: '', sponsor: '', identifier: '' }],
         collaborators: []
@@ -59,7 +57,6 @@ export const NewProjectGeneralData = hh(class NewProjectGeneralData extends Comp
       errors: {
         studyDescription: false,
         pTitle: false,
-        subjectProtection: false,
         fundings: false
       }
     };
@@ -161,7 +158,7 @@ export const NewProjectGeneralData = hh(class NewProjectGeneralData extends Comp
     return (
       WizardStep({
         title: this.props.title, step: 0, currentStep: this.props.currentStep,
-        error: this.props.errors.fundings || this.props.errors.fundingAwardNumber || this.props.errors.studyDescription || this.props.errors.pTitle || this.props.errors.subjectProtection,
+        error: this.props.errors.fundings || this.props.errors.fundingAwardNumber || this.props.errors.studyDescription || this.props.errors.pTitle,
         errorMessage: 'Please complete all required fields'}, [
         Panel({ title: "Requestor Information ", moreInfo: "(person filling the form)", tooltipLabel: "?", tooltipMsg: "Future correspondence regarding this project will be directed to this individual" }, [
           InputFieldText({
@@ -290,24 +287,6 @@ export const NewProjectGeneralData = hh(class NewProjectGeneralData extends Comp
             disabled: false,
             required: false,
             onChange: this.handleInputChange,
-            edit: false
-          }),
-          InputFieldRadio({
-            id: "radioSubjectProtection",
-            name: "subjectProtection",
-            label: "For this project, are you requesting that Broad’s ORSP assume responsibility for submitting regulatory documentation to an outside IRB ",
-            moreInfo: "(as opposed to the study team independently managing the submissions)? *",
-            value: this.state.formData.subjectProtection,
-            optionValues: ["true", "false", "notapplicable"],
-            optionLabels: [
-              "Yes",
-              "No",
-              "N/A - No IRB submission required"
-            ],
-            onChange: this.handleRadioChange,
-            required: true,
-            error: this.props.errors.subjectProtection,
-            errorMessage: "Required field",
             edit: false
           }),
           InputFieldSelect({

--- a/src/main/webapp/projectReview/ProjectReview.js
+++ b/src/main/webapp/projectReview/ProjectReview.js
@@ -30,12 +30,10 @@ export const ProjectReview = hh(class ProjectReview extends Component {
     this.state = {
       generalError: false,
       errorSubmit: false,
-      subjectProtectionError: false,
       descriptionError: false,
       projectTitleError: false,
       editTypeError: false,
       editDescriptionError: false,
-      subjectProtection: false,
       fundingError: false,
       fundingErrorIndex: [],
       internationalCohortsError: false,
@@ -68,7 +66,6 @@ export const ProjectReview = hh(class ProjectReview extends Component {
           feeForServiceWork: '',
           projectTitle: '',
           protocol: '',
-          subjectProtection: null,
           projectAvailability: null,
           attestation: '',
           describeEditType: null,
@@ -121,7 +118,6 @@ export const ProjectReview = hh(class ProjectReview extends Component {
           irbProtocolId: '',
           projectTitle: '',
           protocol: '',
-          subjectProtection: null,
           projectAvailability: null,
           attestation: '',
           describeEditType: null,
@@ -372,7 +368,6 @@ export const ProjectReview = hh(class ProjectReview extends Component {
     project.description = this.state.formData.description;
     project.summary = this.state.formData.projectExtraProps.projectTitle;
     project.fundings = this.getFundings(this.state.formData.fundings);
-    project.subjectProtection = this.state.formData.projectExtraProps.subjectProtection;
     project.attestation = this.state.formData.projectExtraProps.attestation;
     project.projectReviewApproved = this.state.formData.projectExtraProps.projectReviewApproved;
     project.protocol = this.state.formData.projectExtraProps.protocol;
@@ -654,7 +649,6 @@ export const ProjectReview = hh(class ProjectReview extends Component {
   isValid() {
     let descriptionError = false;
     let projectTitleError = false;
-    let subjectProtectionError = false;
     let attestationError = false;
     let editTypeError = false;
     let editDescriptionError = false;
@@ -691,10 +685,6 @@ export const ProjectReview = hh(class ProjectReview extends Component {
       projectTitleError = true;
       generalError = true;
     }
-    if (isEmpty(this.state.formData.projectExtraProps.subjectProtection)) {
-      subjectProtectionError = true;
-      generalError = true;
-    }
     if (isEmpty(this.state.formData.projectExtraProps.attestation)) {
       attestationError = true;
       generalError = true;
@@ -702,7 +692,6 @@ export const ProjectReview = hh(class ProjectReview extends Component {
     this.setState(prev => {
       prev.descriptionError = descriptionError;
       prev.projectTitleError = projectTitleError;
-      prev.subjectProtectionError = subjectProtectionError;
       prev.attestationError = attestationError;
       prev.editDescriptionError = editDescriptionError;
       prev.editTypeError = editTypeError;
@@ -713,8 +702,7 @@ export const ProjectReview = hh(class ProjectReview extends Component {
       return prev;
     });
 
-    return !subjectProtectionError &&
-      !attestationError &&
+    return !attestationError &&
       !projectTitleError &&
       !descriptionError &&
       !editTypeError &&
@@ -1019,25 +1007,6 @@ export const ProjectReview = hh(class ProjectReview extends Component {
             onChange: this.handleProjectExtraPropsChange,
             valueEdited: isEmpty(this.state.current.projectExtraProps.protocol) === !isEmpty(this.state.formData.projectExtraProps.protocol),
             edit: true
-          }),
-          InputFieldRadio({
-            id: "radioSubjectProtection",
-            name: "subjectProtection",
-            label: "For this project, are you requesting that Broad’s ORSP assume responsibility for submitting regulatory documentation to an outside IRB ",
-            moreInfo: "(as opposed to the study team independently managing the submissions)?",
-            value: this.state.formData.projectExtraProps.subjectProtection,
-            currentValue: this.state.current.projectExtraProps.subjectProtection,
-            optionValues: ["true", "false", "notapplicable"],
-            optionLabels: [
-              "Yes",
-              "No",
-              "N/A - No IRB submission required"
-            ],
-            onChange: this.handleProjectExtraPropsChangeRadio,
-            required: true,
-            readOnly: this.state.readOnly,
-            error: this.state.subjectProtectionError,
-            errorMessage: "Required field"
           }),
           InputFieldSelect({
             label: "IRB-of-record",


### PR DESCRIPTION
## Addresses
- https://broadinstitute.atlassian.net/browse/BTRX-708
- https://broadinstitute.atlassian.net/browse/BTRX-709

## Changes
- Delete all options but "New Project" in the "Admin" Top Nav.
- Delete "Subject Protection" question from New Project flow and Review Project.

## Testing
- As an Admin user, the "Admin" drop down in the Header should only show "New Project" option.
- When creating or reviewing a Project, "Subject Protection" related question should not appear any more.

---

- [x] **Submitter**: Verify all tests go green, including CI tests
- [x] **Submitter**: Get a thumb from Belatrix
- [x] **Submitter**: Get a thumb from @rushtong
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
