### PR TITLE
Feature - Hotfix 

### DIFF
--- a/grails-app/taglib/org/broadinstitute/orsp/AuthTagLib.groovy
+++ b/grails-app/taglib/org/broadinstitute/orsp/AuthTagLib.groovy
@@ -35,6 +35,15 @@ class AuthTagLib {
     }
 
     /**
+     * Renders the tag body when the user has one of the ADMIN roles
+     */
+    def isAdmin = { attrs, body ->
+        if (SupplementalRole.isAdmin(session["roles"] as Collection<String>)) {
+            out << body()
+        }
+    }
+
+    /**
      * Renders the tag body when the user does not have an ORSP role
      */
     def isNotOrsp = { attrs, body ->

--- a/grails-app/views/base/_topNav.gsp
+++ b/grails-app/views/base/_topNav.gsp
@@ -30,7 +30,7 @@
                     </li>
                     </auth:isNotViewer>
                     
-                    <auth:isOrsp>
+                    <auth:isAdmin>
                         <li class="dropdown">
                             <a href="#" class="dropdown-toggle" data-toggle="dropdown">Admin <b class="caret"></b></a>
                             <ul class="dropdown-menu">
@@ -43,7 +43,7 @@
                                 <li><a href="${createLink(controller: 'user', action: 'rolesManagement')}">Roles Management</a></li>
                             </ul>
                         </li>
-                    </auth:isOrsp>
+                    </auth:isAdmin>
                 </auth:isAuthenticated>
             </ul>
 

--- a/grails-app/views/layouts/main_component.gsp
+++ b/grails-app/views/layouts/main_component.gsp
@@ -137,7 +137,7 @@
         userNameSearchUrl: "${createLink(controller: 'search', action: 'getMatchingUsers')}",
         sourceDiseases: "${createLink(controller: 'search', action: 'getMatchingDiseaseOntologies')}",
         isAdmin: ${session.isAdmin},
-        isViewer: "${session.isViewer}",
+        isViewer: ${session.isViewer},
         rejectProjectUrl: "${createLink(controller: 'project', action: 'delete')}",
         updateProjectUrl: "${createLink(controller: 'project', action: 'update')}",
         discardReviewUrl: "${createLink(controller: 'issueReview', action: 'delete')}",

--- a/grails-app/views/layouts/main_component.gsp
+++ b/grails-app/views/layouts/main_component.gsp
@@ -136,7 +136,7 @@
         serverURL: "${webRequest.baseUrl}",
         userNameSearchUrl: "${createLink(controller: 'search', action: 'getMatchingUsers')}",
         sourceDiseases: "${createLink(controller: 'search', action: 'getMatchingDiseaseOntologies')}",
-        isAdmin: "${session.isAdmin}",
+        isAdmin: ${session.isAdmin},
         isViewer: "${session.isViewer}",
         rejectProjectUrl: "${createLink(controller: 'project', action: 'delete')}",
         updateProjectUrl: "${createLink(controller: 'project', action: 'update')}",

--- a/src/main/webapp/components/Documents.js
+++ b/src/main/webapp/components/Documents.js
@@ -128,7 +128,7 @@ export const Documents = hh(class Documents extends Component {
           className: "btn buttonSecondary",
           style: addDocumentBtn,
           onClick: this.addDocuments,
-          isRendered: !this.props.user.isViewer,
+          isRendered: !component.isViewer,
         }, ["Add Document"]),
         Table({
           headers: headers,
@@ -136,8 +136,8 @@ export const Documents = hh(class Documents extends Component {
           sizePerPage: 10,
           paginationSize: 10,
           handleDialogConfirm: this.props.handleDialogConfirm,
-          isAdmin: this.props.user.isAdmin,
-          isViewer: this.props.user.isViewer,
+          isAdmin: component.isAdmin,
+          isViewer: component.isViewer,
           reviewFlow: true,
           pagination: true,
           remove: this.remove
@@ -150,7 +150,7 @@ export const Documents = hh(class Documents extends Component {
       }, [
         Panel({
           title: "Data Use Restrictions",
-          isRendered: (this.props.isAdmin || this.props.user.isViewer) && this.findDul()
+          isRendered: (component.isAdmin || component.isViewer) && this.findDul()
         }, [
           h3({
             style: {'marginTop': '10px'},
@@ -172,14 +172,14 @@ export const Documents = hh(class Documents extends Component {
                 className: "btn buttonSecondary",
                 style: {'marginRight': '15px'},
                 onClick: this.newRestriction,
-                isRendered: this.props.restrictionId === null && this.findDul() && !this.props.user.isViewer,
+                isRendered: this.props.restrictionId === null && this.findDul() && !component.isViewer,
               },
               ["Create Restriction"]),
             button({
                 className: "btn buttonSecondary",
                 style: {'marginRight': '15px'},
                 onClick: this.editRestriction,
-                isRendered: this.props.restrictionId !== null && !this.props.user.isViewer,
+                isRendered: this.props.restrictionId !== null && !component.isViewer,
               },
               ["Edit Restrictions"]),
             button({
@@ -200,8 +200,8 @@ export const Documents = hh(class Documents extends Component {
               paginationSize: 10,
               unlinkProject: this.props.handleUnlinkProject,
               handleRedirectToInfoLink: this.props.handleRedirectToInfoLink,
-              isAdmin: this.props.isAdmin,
-              isViewer: this.props.user.isViewer
+              isAdmin: component.isAdmin,
+              isViewer: component.isViewer
             })
           ])
         ])

--- a/src/main/webapp/components/RoleManagementEdit.js
+++ b/src/main/webapp/components/RoleManagementEdit.js
@@ -9,7 +9,6 @@ import { AlertMessage } from "./AlertMessage";
 
 const READ_ONLY = USER_ROLES['Read Only'].value;
 const ADMIN = USER_ROLES['Admin'].value;
-const COMPLIANCE_OFFICE = 'Compliance Office';
 
 export const RoleManagementEdit = hh(class RoleManagementEdit extends Component {
 
@@ -47,10 +46,8 @@ export const RoleManagementEdit = hh(class RoleManagementEdit extends Component 
     if (!isEmpty(this.props.userData)) {
       this.props.userData.roles.forEach(item => {
         Object.keys(USER_ROLES).forEach(role => {
-          if (USER_ROLES[role].value === item) {
+          if (USER_ROLES[role].alias.includes(item)) {
             checkedRoles[USER_ROLES[role].value] = true
-          } else if (COMPLIANCE_OFFICE === item) {
-            checkedRoles[ADMIN] = true
           }
         });
       });

--- a/src/main/webapp/consentGroupReview/ConsentGroupReview.js
+++ b/src/main/webapp/consentGroupReview/ConsentGroupReview.js
@@ -43,7 +43,6 @@ export const ConsentGroupReview = hh(class ConsentGroupReview extends Component 
       requestClarification: false,
       readOnly: true,
       isAdmin: false,
-      isViewer: false,
       disableApproveButton: false,
       reviewSuggestion: false,
       submitted: false,
@@ -213,10 +212,6 @@ export const ConsentGroupReview = hh(class ConsentGroupReview extends Component 
       this.setState(() => { throw error; });
     });
   };
-
-  isViewer = () => {
-    return component.isViewer === "true";
-  }
 
   parseInstSources(instSources) {
     let instSourcesArray = [];
@@ -842,7 +837,7 @@ export const ConsentGroupReview = hh(class ConsentGroupReview extends Component 
           className: "btn buttonPrimary floatRight",
           style: { 'marginTop': '15px' },
           onClick: this.enableEdit(),
-          isRendered: this.state.readOnly === true && !this.isViewer(),
+          isRendered: this.state.readOnly === true && !component.isViewer,
         }, ["Edit Information"]),
         button({
           className: "btn buttonSecondary floatRight",
@@ -1006,7 +1001,7 @@ export const ConsentGroupReview = hh(class ConsentGroupReview extends Component 
           button({
             className: "btn buttonPrimary floatLeft",
             onClick: this.enableEdit(),
-            isRendered: this.state.readOnly === true && !this.isViewer(),
+            isRendered: this.state.readOnly === true && !component.isViewer(),
           }, ["Edit Information"]),
 
           button({

--- a/src/main/webapp/consentGroupReview/ConsentGroupReview.js
+++ b/src/main/webapp/consentGroupReview/ConsentGroupReview.js
@@ -1001,7 +1001,7 @@ export const ConsentGroupReview = hh(class ConsentGroupReview extends Component 
           button({
             className: "btn buttonPrimary floatLeft",
             onClick: this.enableEdit(),
-            isRendered: this.state.readOnly === true && !component.isViewer(),
+            isRendered: this.state.readOnly === true && !component.isViewer,
           }, ["Edit Information"]),
 
           button({

--- a/src/main/webapp/projectReview/ProjectReview.js
+++ b/src/main/webapp/projectReview/ProjectReview.js
@@ -241,10 +241,6 @@ export const ProjectReview = hh(class ProjectReview extends Component {
       });
   }
 
-  isViewer = () => {
-    return component.isViewer === "true";
-  };
-
   getUsersArray(array) {
     let usersArray = [];
     if (array !== undefined && array !== null && array.length > 0) {
@@ -808,13 +804,13 @@ export const ProjectReview = hh(class ProjectReview extends Component {
           className: "btn buttonPrimary floatRight",
           style: { 'marginTop': '15px' },
           onClick: this.enableEdit(),
-          isRendered: this.state.readOnly === true && !this.isViewer()
+          isRendered: this.state.readOnly === true && !component.isViewer
         }, ["Edit Information"]),
         button({
           className: "btn buttonSecondary floatRight",
           style: { 'marginTop': '15px' },
           onClick: this.redirectToConsentGroupTab,
-          isRendered: this.state.readOnly === true && !this.isViewer()
+          isRendered: this.state.readOnly === true && !component.isViewer
         }, ["Add Sample/Data Cohort"]),
 
         button({
@@ -1141,7 +1137,7 @@ export const ProjectReview = hh(class ProjectReview extends Component {
           button({
             className: "btn buttonPrimary floatLeft",
             onClick: this.enableEdit(),
-            isRendered: this.state.readOnly === true && !this.isViewer()
+            isRendered: this.state.readOnly === true && !component.isViewer
           }, ["Edit Information"]),
 
           button({
@@ -1157,7 +1153,7 @@ export const ProjectReview = hh(class ProjectReview extends Component {
             disabled: isEmpty(this.state.editedForm) ?
               !this.compareObj("formData", "editedForm") && this.compareObj("formData", "current")
               : this.compareObj("formData", "editedForm"),
-            isRendered: this.state.readOnly === false && !this.isViewer()
+            isRendered: this.state.readOnly === false && !component.isViewer
           }, ["Submit Edits"]),
 
           /*visible for Admin in readOnly mode and if the project is in "pending" status*/

--- a/src/main/webapp/util/roles.js
+++ b/src/main/webapp/util/roles.js
@@ -1,6 +1,6 @@
 export const USER_ROLES = {
-  'Admin' : { label: 'Admin', value :'orsp', index: 0 },
-  'Read Only' : { label: 'Read Only', value :'ro_admin', index: 1 }
+  'Admin' : { label: 'Admin', value :'orsp', alias: ['orsp', 'admin', 'Compliance Office'], index: 0 },
+  'Read Only' : { label: 'Read Only', value :'ro_admin', alias: ['ro_admin'], index: 1 }
 };
 
 export const formatRoleName = (roles) => {


### PR DESCRIPTION
## Addresses
There's no story for this fix

## Changes
- Change roles that are able to see Admin drop down from top nav, to be consistent to rest of the app.
- Change isAdmin and isViewer global variables to be Boolean instead of strings.
- Fix Compliance Office to default check Admin, in Roles Management

## Testing
- Check that a read only user cannot perform any admin action across the app.
- Verify that read only users cannot see Admin dropdown in the top navigation options
- Users with Compliance Office role, will be seen as Admins in Roles management table. Also as a default checked option in its edition.
---

- [x] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Get a thumb from Belatrix
- [ ] **Submitter**: Get a thumb from @rushtong
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
