### PR TITLE
Remove ccl delete logic

### DIFF
--- a/grails-app/services/org/broadinstitute/orsp/IssueService.groovy
+++ b/grails-app/services/org/broadinstitute/orsp/IssueService.groovy
@@ -163,7 +163,7 @@ class IssueService implements UserInfo {
             issue.removeFromFundings(it)
             it.delete(hard: true)
         }
-
+        
         // Remaining properties are IssueExtraProperty associations
         Collection<IssueExtraProperty> propsToDelete = findPropsForDeleting(issue, input)
         Collection<IssueExtraProperty> propsToSave = getSingleValuedPropsForSaving(issue, input)

--- a/grails-app/services/org/broadinstitute/orsp/IssueService.groovy
+++ b/grails-app/services/org/broadinstitute/orsp/IssueService.groovy
@@ -164,30 +164,6 @@ class IssueService implements UserInfo {
             it.delete(hard: true)
         }
 
-        def sampleCollectionIds = input.get('samples')
-        Collection<ConsentCollectionLink> sclOld = ConsentCollectionLink.findAllByConsentKey(issue.projectKey)
-
-        def deletableConsentCollectionLinks = sclOld.findAll { !sampleCollectionIds.contains(it.sampleCollectionId)}
-        if (!deletableConsentCollectionLinks.isEmpty()) {
-            deletableConsentCollectionLinks.each {
-                it.delete(hard: true)
-                sclOld.remove(it)
-            }
-        }
-
-        def newSampleCollectionLinks = sampleCollectionIds.findAll { !sclOld.sampleCollectionId.contains(it) }
-
-        newSampleCollectionLinks.each {
-            if (!sclOld.contains(it)) {
-                new ConsentCollectionLink(
-                        projectKey: issue.source,
-                        consentKey: issue.projectKey,
-                        sampleCollectionId: it,
-                        creationDate: new Date()
-                ).save(flush: true)
-            }
-        }
-
         // Remaining properties are IssueExtraProperty associations
         Collection<IssueExtraProperty> propsToDelete = findPropsForDeleting(issue, input)
         Collection<IssueExtraProperty> propsToSave = getSingleValuedPropsForSaving(issue, input)


### PR DESCRIPTION
## Addresses
No story

## Changes
- Removed old delete Consent Collection Link logic from Issue update. This is being handled elsewhere
---

- [x] **Submitter**: Verify all tests go green, including CI tests
- [x] **Submitter**: Get a thumb from Belatrix
- [x] **Submitter**: Get a thumb from @rushtong
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
