### PR TITLE
BTRX - 442 - Create a user guide for the new system

### DIFF
--- a/grails-app/views/index/about.gsp
+++ b/grails-app/views/index/about.gsp
@@ -1,230 +1,31 @@
 <html>
-<head>
-    <meta name="layout" content="main">
-    <title>About</title>
-</head>
+    <head>
+        <meta name="layout" content="main">
+        <title>About</title>
+    </head>
 
-<body>
-<div class="col-md-10">
+    <body>
+        <div class="col-md-10">
 
-<h3>About the ORSP Portal</h3>
+            <h3>About the ORSP Portal</h3>
 
-<p>
-    <a href="https://iwww.broadinstitute.org/sponsored-research/research-subject-protection/office-research-subject-protection">ORSP on the Broad Intranet</a>
-</p>
+            <p>
+                <a href="https://iwww.broadinstitute.org/sponsored-research/research-subject-protection/office-research-subject-protection">ORSP on the Broad Intranet</a>
+            </p>
 
-<p>
-    <g:render template="/index/aboutBlurb"/>
-</p>
+            <p>
+                <g:render template="/index/aboutBlurb"/>
+            </p>
 
-<div id="helpContent" class="container col-lg-12">
+            <h3>User Guide</h3>
+                <p>
+                    To access detailed instructions about how to use the ORSP portal, please visit:
+                    <br/>
 
-<h1>User Guide</h1>
-<ul>
-    <li><a href="#nhsr">The "Not Human Subjects Research" Regulatory Category</a>
-        <ul>
-            <li><a href="#nhsr_intro">Introduction</a></li>
-            <li><a href="#nhsr_create">Creating a 'Not Human Subjects Research' Project</a></li>
-        </ul>
-    </li>
-    <li><a href="#ne">The "Not Engaged in Human Subjects Research" Regulatory Category</a>
-        <ul>
-            <li><a href="#ne_intro">Introduction</a></li>
-            <li><a href="#ne_create">Creating a "Not Engaged in Human Subjects Research" Project</a></li>
-        </ul>
-    </li>
-    <li><a href="#irb">IRB Protocol Records</a>
-        <ul>
-            <li><a href="#irb_intro">Introduction</a></li>
-            <li><a href="#irb_create">Creating a New IRB Protocol Record</a></li>
-        </ul>
-    </li>
-    <li><a href="#consent">Consent Groups</a>
-        <ul>
-            <li><a href="#consent_intro">Introduction</a></li>
-            <li><a href="#consent_create">Creating a New Consent Group</a></li>
-        </ul>
-    </li>
-</ul>
-
-<h2>User Guide Overview</h2>
-
-<p>
-    The Office of Research Subject Protection (ORSP) at the Broad Institute is committed to helping its community
-    members adhere to federal regulations and institutional policies governing the protection of human subjects who
-    make our research possible.  To fulfill that mission, the Broad must ensure appropriate regulatory oversight
-    and reliable documentation storage. The ORSP Portal (accessible at <a
-        href="http://orsp.broadinstitute.org/">http://orsp.broadinstitute.org/</a>)
-is an online platform where Broad staff members can upload documents for ORSP review (either as stand-alone
-submissions, or in preparation for an IRB protocol application), store consent forms and regulatory approvals, and
-search for data use restrictions. Community members are strongly encouraged to email
-    <a href="mailto:orsp-portal@broadinstitute.org">orsp-portal@broadinstitute.org</a> with any questions or requests for assistance.
-</p>
-
-
-<h2 id="nhsr">The "Not Human Subjects Research" Regulatory Category</h2>
-
-<h3 id="nhsr_intro">Introduction</h3>
-
-<p>
-    The U.S. Code of Federal Regulations requires that research involving human subjects undergo review by an
-    Institutional Review Board (IRB).  Frequently, research at the Broad involves use of data and biological
-    specimen derived from human subjects, however this does not mean that the activities themselves constitute
-    human subjects research.  Many projects fall into the regulatory category of "not human subjects research"
-    (NHSR).  In other situations, the Broad is considered to be "not engaged" in another scientist's human subjects
-    research.  These nuances can be difficult to understand, and ORSP recommends that before submitting a "NHSR"
-    or "Not Engaged" determination request, Project Managers and/or Principal Investigators seek guidance by
-    emailing <a href="mailto:orsp-portal@broadinstitute.org">orsp-portal@broadinstitute.org</a>.  If a "NHSR" request is
-appropriate, please follow the steps below to file your electronic submission via the ORSP IRB Portal.
-</p>
-
-<h2 id="nhsr_create">Creating a 'Not Human Subjects Research' Project</h2>
-
-<ul>
-    <li>Log into the portal at <a
-            href="http://orsp.broadinstitute.org/">http://orsp.broadinstitute.org/</a> using a Broad username and password.
-    </li>
-    <li>At the top of the page, select  New</li>
-    <li>From the options that appear, select  Not Human Subjects Research Project</li>
-    <li>Complete each field in the form as directed.</li>
-    <li>When complete, click Add at the bottom of the page.  This will establish the project in the portal system, and assign it a number.  [Note: this is the ORSP Determination Number to reference when entering regulatory information into the Genomic Platform’s Mercury system.]</li>
-    <li>The next page that will load stores all the information associated with the project.  There, one can:
-        <ul>
-            <li>View the information entered to date under the Broad Project Information tab.</li>
-            <li>Submit consent forms or any other documentation under the Documents tab.  To do this, select the document type from the pull-down menu next to the Attach button.  Click  Attach, and follow the instructions for uploading the document (documents can be dragged and dropped, or selected from a computer.)  There is also a button in this section that allows one to  Add a Consent Group. (This function is described in greater detail below.)  It establishes an entity within the system for all documents associated with a particular sample cohort.  Creating a Consent Group only needs to be done once for each cohort.  If someone else at the Broad later uses samples from the same cohort for a different project, the Consent Group will already exist in the Portal; it does not need to be entered again.  To add a previously entered cohort to your new project, simply click on Use Existing Consent Group and start typing in the last name of the PI on the consent form; the name should auto-fill, or, one can fully enter the name.</li>
-            <li>Enter any additional information or clarifications under the Comments tab.</li>
-            <li>View all activity on your project under the History tab.</li>
-        </ul>
-    </li>
-    <li>The Workspace tab is where portal users engage directly with ORSP. Here, the PI/PM is able to submit projects to ORSP for review, and resubmit them if any clarifications or modifications are needed. There is also an option to Abandon a project that has been partially entered, but is no longer moving forward.  Selecting Abandon means that ORSP will not review the information entered, although it will remain in the system for future reference.  When an application is ready for review, click Submit to ORSP under the Workspace tab.  The status bar at the top of the page will change to Assigned to Office of Research Subject Protection, and a checkmark will appear next to Project Has Been Submitted on the right hand side of the page. You will also receive an email notification of this activity.</li>
-    <li>If ORSP has any questions or requires any changes to the form, you will receive another email notification, and the Assigned to status will change back to the PM/PI.  Follow-up questions from ORSP will be visible under the Comments tab.  If modifications are required, fields can be edited by returning to the information previously entered under the Broad Project Information tab.  Select Update at the bottom of the page to save changes.   Return to the Workspace tab, and click Submit to ORSP.</li>
-    <li>Once the submission has been approved, you will receive an email regarding the determination and the status bar at the top of the page will indicate Completed.  The status will also be reflected in the project’s entry on the home page.</li>
-    <li>If a hard copy of the application and approval is needed, please email <a
-            href="mailto:orsp-portal@broadinstitute.org">orsp-portal@broadinstitute.org</a>.</li>
-</ul>
-
-<h2 id="ne">The "Not Engaged in Human Subjects Research" Regulatory Category</h2>
-
-<h3 id="ne_intro">Introduction</h3>
-
-<p>
-    The U.S. Code of Federal Regulations requires that research involving human subjects undergo review by an Institutional Review Board (IRB).  Frequently, research at the Broad involves use of data and biological specimens derived from other human subjects research studies, however this does not mean that the Broad, as an institution, is "engaged" in that research.  Many projects fall into the regulatory category of "not engaged in human subjects research."  This is different from "not human subjects research," in that it means Broad researchers are collaborating to some degree with researchers who are conducting human subjects research elsewhere (as opposed to working with samples purchased from a vendor, for example).
-</p>
-
-<p>
-    These nuances can be difficult to understand, and ORSP recommends that before submitting a "NHSR" or "Not Engaged" determination request, PIs or their designees seek guidance by emailing orsp@broadinstitute.com.  If a "Not Engaged" request is appropriate, please follow the steps below to file your electronic submission via the ORSP IRB Portal.
-</p>
-
-<h3 id="ne_create">Creating a "Not Engaged in Human Subjects Research" Project</h3>
-
-<ul>
-    <li>Log into the portal <a
-            href="http://orsp.broadinstitute.org/">http://orsp.broadinstitute.org/</a> with a Broad username and password.
-    </li>
-    <li>At the top of the page, select New.</li>
-    <li>From the options that appear, select  Not Engaged Project.</li>
-    <li>Complete each field in the form as directed.</li>
-    <li>When complete, click Add at the bottom of the page.  This will establish the project in the portal system, and assign it a number. [Note: this is the ORSP Determination Number to reference when entering regulatory information into the Genomic Platform's Mercury system.]</li>
-    <li>The next page stores all the information associated with the project.  There, one can:
-        <ul>
-            <li>View the information entered to date under the Broad Project Information tab.</li>
-            <li>Submit consent forms or any other documentation under the Documents tab.  To do this, select the document type from the pull-down menu next to the Attach button.  Click  Attach, and follow the instructions for uploading the document (documents can be dragged and dropped, or selected from a computer.)  There is also a button in this section that allows one to  Add a Consent Group. (This function is described in greater detail below.)  It establishes an entity within the system for all documents associated with a particular sample cohort.  Creating a Consent Group only needs to be done once for each cohort.  If someone else at the Broad later uses samples from the same cohort for a different project, the Consent Group will already exist in the Portal; it does not need to be entered again.  To add a previously entered cohort to your new project, simply click on Use Existing Consent Group and start typing in the last name of the PI on the consent form; the name should auto-fill, or, one can fully enter the name.</li>
-            <li>Enter any additional information or clarifications under the Comments tab.</li>
-            <li>View all activity on your project under the History tab.</li>
-            <li>The Workspace tab is where portal users engage directly with ORSP.  Here, the PI/PM is able to submit projects to ORSP for review, and resubmit them if any clarifications or modifications are needed. There is also an option to Abandon a project that has been partially entered, but is no longer moving forward.  Selecting Abandon means that ORSP will not review the information entered, although it will remain in the system for future reference.</li>
-        </ul>
-    </li>
-    <li>When an application is ready for review, click Submit to ORSP under the Workspace tab.  The status bar at the top of the page will change to Assigned to Office of Research Subject Protection, and a checkmark will appear next to Project Has Been Submitted on the right hand side of the page.</li>
-    <li>If ORSP has any questions or requires any changes to the form, the Assigned to status will change back to the PM/PI.  Follow-up questions from ORSP will be visible under the Comments tab.  If modifications are required, fields can be edited by returning to the information previously entered under the Broad Project Information tab.  Select Update at the bottom of the page to save changes.   Return to the Workspace tab, and click Submit to ORSP.</li>
-    <li>Once the submission has been approved, the status bar at the top of the page will indicate Completed.  The status will also be reflected in the project's entry on the home page.</li>
-    <li>If a hard copy of the application and approval is needed, please email
-        <a href="mailto:orsp-portal@broadinstitute.org">orsp-portal@broadinstitute.org</a>.</li>
-</ul>
-
-<h2 id="irb">IRB Protocol Records</h2>
-
-<h3 id="irb_intro">Introduction</h3>
-
-<p>
-    This section of the ORSP portal allows entry of information about a future IRB protocol, and storage of associated documents.  Please note that entering information into the portal does not mean that anything has been submitted to, reviewed or approved by an actual IRB.  It simply allows you to store searchable information for future use, and to provide documents to ORSP for review prior to IRB submission.  Actual IRB applications are submitted directly to the IRB of record.
-</p>
-
-<p>
-    It's also important to note that each of the three primary IRBs of record (Partners, DFCI and MIT) at Broad have a unique application structure.
-</p>
-
-<ul>
-    <li>Partners has a stand-alone electronic application system</li>
-    <li>MIT conducts business primarily through paper-based submissions and email</li>
-    <li>DFCI is a email/electronic system hybrid</li>
-</ul>
-
-<p>
-    Despite differences in the amount and type of documentation required, use of the ORSP portal is consistent across all the IRBs.  IRB applications are completed outside the portal system, and either uploaded for ORSP review or reviewed by ORSP in an external IRB system (e.g. Partners' Insight).  When ready for submission, ORSP alerts the PM/PI and, depending on the particular IRB, either ORSP or the PM/PI submits the final application.  ORSP can provide guidance regarding the required forms for each IRB.
-</p>
-
-<h3 id="irb_create">Creating a New IRB Protocol Record</h3>
-
-<ul>
-    <li>Log into the portal <a
-            href="http://orsp.broadinstitute.org/">http://orsp.broadinstitute.org/</a> with a Broad username and password.
-    </li>
-    <li>At the top of the page, select New</li>
-    <li>From the options that appear, select IRB Protocol</li>
-    <li>In the section labeled Broad IRB, select the IRB of the institution where the Broad PI maintains his/her primary affiliation.  If it is unclear which option to click, contact ORSP for help.</li>
-    <li>Once all the fields have been completed, select Add at the bottom of the page.</li>
-    <li>The next page stores all the information associated with the project.  There, one can:
-        <ul>
-            <li>View the information entered to date under the Broad Project Information tab.</li>
-            <li>Submit consent forms or any other documentation under the Documents tab.  To do this, select the document type from the pull-down menu next to the Attach button.  Click  Attach, and follow the instructions for uploading the document (documents can be dragged and dropped, or selected from a computer.)  There is also a button in this section that allows one to  Add a Consent Group. (This function is described in greater detail below.)  It establishes an entity within the system for all documents associated with a particular sample cohort.  Creating a Consent Group only needs to be done once for each cohort.  If someone else at the Broad later uses samples from the same cohort for a different project, the Consent Group will already exist in the Portal; it does not need to be entered again.  To add a previously entered cohort to your new project, simply click on Use Existing Consent Group and start typing in the last name of the PI on the consent form; the name should auto-fill, or, one can fully enter the name.</li>
-            <li>Enter any additional information or clarifications under the Comments tab.</li>
-            <li>View all activity on your project under the History tab.</li>
-            <li>The Workspace tab is where portal users engage directly with ORSP.  Here, the PI/PM is able to submit projects to ORSP for review, and resubmit them if any clarifications or modifications are needed. There is also an option to Abandon a project that has been partially entered, but is no longer moving forward.  Selecting Abandon means that ORSP will not review the information entered, although it will remain in the system for future reference.</li>
-        </ul>
-    </li>
-    <li>When project documentation is ready for ORSP review, click on the appropriate Submit to ORSP button in the Workspace.   There are two categories of documents that can be submitted, reflecting two stages of ORSP review.  The first is "Supporting Documents," which includes consent forms and approval letters from collaborators.  The second is "Application," which would include the various forms required by the IRBs for submission to their respective institutions.  ORSP can provide guidance regarding the required forms for each IRB.   In the case of an IRB that has its own electronic system, ORSP staff can review a draft application in that system; there is no need to upload it manually into the Portal.   Please do not submit any applications (electronic or manual) to an IRB prior to ORSP review.</li>
-    <li>If ORSP has any questions or comments, these will be entered under the Comments tab, and the Assigned to status will revert to the submitter.  If modifications are required, fields can be edited by:
-        <ul>
-            <li>Returning to the information entered under the Broad Project Information tab</li>
-            <li>Select Update at the bottom of the page to save changes.</li>
-            <li>Return to the Workspace tab, and select Submit to ORSP</li>
-        </ul>
-    </li>
-    <li>Both stages of review (supporting documents and IRB application) are documented in the series of checkboxes on the right hand side of the page. Email notifications are triggered each time the project status changes.</li>
-    <li>Once the application has been signed (as needed) and submitted, the portal tracks the progression of the application at the IRB.  This allows both the PM/PI and ORSP to know where the project stands at any given time.</li>
-    <li>If the "IRB Requests Modification," the project will revert to a state in which documents can once again be submitted to ORSP for review, prior to resubmission at the IRB of record.</li>
-    <li>Upon receipt of final IRB approval, the approval letter can be stored under the Documents tab.</li>
-</ul>
-
-
-<h2 id="consent">Consent Groups</h2>
-
-<h3 id="consent_intro">Introduction</h3>
-
-<p>
-    Consent Groups are similar in many ways to a BSP "collection." Each unique set of samples stored at the Broad is associated with a consent form (or, in some cases, a "waiver of consent" from the IRB).  The consent is provided to the Broad by the collaborators from whom the samples are obtained.   It outlines how samples may be used, and under what circumstances they may be shared.   Review of new Broad research projects (by either an IRB or ORSP) always includes an examination of the consent form.   The portal provides a mechanism for PIs and PMs to share consent forms with ORSP for review (either as the single reviewing entity, or in preparation for an IRB submission), as well as exchange questions and comments.  It also stores these forms for future reference.
-</p>
-
-<p>
-    The Consent Group feature within the portal establishes an entity within the system for all documents associated with a particular sample cohort.  For example, if a set of samples are received from Dr. Anderson at Oklahoma State University, these samples were at one point collected from subjects using a particular consent form.  If Dr. Anderson is the PI of the protocol at Oklahoma (protocol #2341) using that consent, then the Consent Group will be labeled Anderson/2341 --an identifier that is automatically generated by the system.   Once a Consent Group has been established, it can be associated with any Broad project using that particular set of samples; there is no need for different PIs or PMs to enter the same documents more than once.   Consent Groups may also link to Data Use Records, including Data Use (DU) Letters.
-</p>
-
-<h3 id="consent_create">Creating a New Consent Group</h3>
-
-<ul>
-    <li>Log into the portal <a
-            href="http://orsp.broadinstitute.org/">http://orsp.broadinstitute.org/</a> with a Broad username and password.
-    </li>
-    <li>At the top of the page, select New</li>
-    <li>From the options that appear, select Consent Group</li>
-    <li>Several fields will appear that will help to name the consent group, and enable future searching for these terms.  The portal's automatic naming convention is &lt;last name of PI on the consent form/collaborator's protocol number&gt;.  If there is no name listed on the consent, or if you need further guidance about how to complete these fields, please email <a
-            href="mailto:orsp-portal@broadinstitute.org">orsp-portal@broadinstitute.org</a> for assistance.</li>
-    <li>Once you have entered the available information, select Add.</li>
-    <li>Documents associated with this particular set of samples can then be uploaded. These may include consent forms, IRB approval letters, correspondence from local IRBs, or other relevant items.</li>
-</ul>
-
-</div>
-
-</div>
-</body>
+                    <a href="https://intranet.broadinstitute.org/research-subject-protection/orsp-online-portal-submission-system">
+                        https://intranet.broadinstitute.org/research-subject-protection/orsp-online-portal-submission-system
+                    </a>
+                </p>
+        </div>
+    </body>
 </html>


### PR DESCRIPTION
## Addresses
[BTRX-442](https://broadinstitute.atlassian.net/browse/BTRX-442) : ORSP: Create a user guide for the new system

## Changes
- Change user's guide text in "About" page.

## Testing
- Access to About page from top navigation bar link. The new user guide text should be there.

---

- [x] **Submitter**: Verify all tests go green, including CI tests
- [x] **Submitter**: Get a thumb from Belatrix
- [x] **Submitter**: Get a thumb from @rushtong
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
