### PR TITLE
BTRX - 723 - Display new Status in Result Table

### DIFF
--- a/grails-app/controllers/org/broadinstitute/orsp/SearchController.groovy
+++ b/grails-app/controllers/org/broadinstitute/orsp/SearchController.groovy
@@ -150,7 +150,7 @@ class SearchController implements UserInfo {
                 options.userName ||
                 options.fundingInstitute ||
                 options.irbsOfRecord) {
-                rows = queryService.findIssues(options).collect {
+            rows = queryService.findIssues(options).collect {
                 Map<String, Object> arguments = IssueUtils.generateArgumentsForRedirect(it.type, it.projectKey, null)
 
                 String link = applicationTagLib.createLink([controller: arguments.get("controller"), action: arguments.get("action"), params: arguments.get("params"), absolute: true])

--- a/grails-app/controllers/org/broadinstitute/orsp/SearchController.groovy
+++ b/grails-app/controllers/org/broadinstitute/orsp/SearchController.groovy
@@ -150,7 +150,7 @@ class SearchController implements UserInfo {
                 options.userName ||
                 options.fundingInstitute ||
                 options.irbsOfRecord) {
-            rows = queryService.findIssues(options).collect {
+                rows = queryService.findIssues(options).collect {
                 Map<String, Object> arguments = IssueUtils.generateArgumentsForRedirect(it.type, it.projectKey, null)
 
                 String link = applicationTagLib.createLink([controller: arguments.get("controller"), action: arguments.get("action"), params: arguments.get("params"), absolute: true])
@@ -161,7 +161,7 @@ class SearchController implements UserInfo {
                         linkDisabled: permissionService.issueIsForbidden(it, userName, isAdmin, isViewer),
                         title: it.summary,
                         type: it.type,
-                        status: it.status,
+                        status: it.approvalStatus != "Legacy" ? it.approvalStatus : it.status,
                         updated: it.updateDate ? format.format(it.updateDate): "",
                         expiration: it.expirationDate ? format.format(it.expirationDate) : ""
                 ]


### PR DESCRIPTION
## Addresses
[BTRX-723](https://broadinstitute.atlassian.net/browse/BTRX-723) : Display new Status in Result Table

## Changes
- Included new approval status on rendered object.

## Testing
- On search page, when looking for Projects or Consent Groups by using "new statuses" as search parameter, they should appear in the "Status" column

---

- [x] **Submitter**: Verify all tests go green, including CI tests
- [x] **Submitter**: Get a thumb from Belatrix
- [x] **Submitter**: Get a thumb from @rushtong
- [x] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [x] **Submitter**: Delete branch after merge
