### PR TITLE
[No Jira] Move du letter logic to the controller

### DIFF
--- a/grails-app/controllers/org/broadinstitute/orsp/ConsentGroupController.groovy
+++ b/grails-app/controllers/org/broadinstitute/orsp/ConsentGroupController.groovy
@@ -182,10 +182,11 @@ class ConsentGroupController extends AuthenticatedController {
     @Override
     show() {
         Issue issue = queryService.findByKey(params.id)
-        def attachments = issue.attachments?.sort {a,b -> b.createDate <=> a.createDate}
-        def restriction = DataUseRestriction.findByConsentGroupKey(issue.projectKey)
+        Collection<StorageDocument> attachments = issue.attachments?.sort {a,b -> b.createDate <=> a.createDate}
+        boolean duLetter = attachments.any{it.fileType?.startsWith(DU_LETTER)}
+        DataUseRestriction restriction = DataUseRestriction.findByConsentGroupKey(issue.projectKey)
         Collection<String> duSummary = consentService.getSummary(restriction)
-        def collectionLinks = queryService.findCollectionLinksByConsentKey(issue.projectKey)
+        Collection<ConsentCollectionLink> collectionLinks = queryService.findCollectionLinksByConsentKey(issue.projectKey)
 //        def checklistAnswers = ChecklistAnswer.findAllByProjectKey(issue.projectKey)
         [issue: issue,
          collectionLinks: collectionLinks,
@@ -194,7 +195,7 @@ class ConsentGroupController extends AuthenticatedController {
          restriction: restriction,
          duSummary: duSummary,
          tab: params.tab,
-         duLetter: DU_LETTER,
+         duLetter: duLetter,
 //         checklistAnswers: checklistAnswers
         ]
     }

--- a/grails-app/views/consentGroup/show.gsp
+++ b/grails-app/views/consentGroup/show.gsp
@@ -66,7 +66,7 @@
                     <a href="${createLink(controller: "dataUse", action: "show", params: [id: restriction.id])}" class="btn btn-default">View Restrictions</a>
                 </g:if>
                 <g:else>
-                    <g:if test="${attachments*.fileType.contains(duLetter)}">
+                    <g:if test="${duLetter}">
                         <a href="${createLink(controller: "dataUse", action: "create", params: [create: true, id: issue.projectKey, principalInvestigatorName: issue.consent])}" class="btn btn-default">Create Restrictions</a>
                     </g:if>
                 </g:else>


### PR DESCRIPTION
## Addresses
The UI logic around when to show the create data use restriction page was incorrectly looking at only one kind of document type. This PR moves that logic to the controller and looks at any of the kinds of du letters that are now valid.