### PR TITLE
[risk=no] Jackson security update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ repositories {
 
 dependencies {
     // Including explicit transitive dependencies due to security issues:
-    compile (group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.8') {
+    compile (group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.8.2') {
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-annotations'
     }
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.9.8' // Required for databind

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ repositories {
 
 dependencies {
     // Including explicit transitive dependencies due to security issues:
-    compile (group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.8.2') {
+    compile (group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.9.2') {
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-annotations'
     }
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.9.8' // Required for databind


### PR DESCRIPTION
## Addresses
https://broadinstitute-dsp.sourceclear.io/workspaces/jppForw/issues/vulnerabilities/7039290/18759627
https://broadinstitute-dsp.sourceclear.io/workspaces/jppForw/issues/vulnerabilities/7039290/18759626

```
This vulnerability is in a direct dependency. Vulnerable library jackson-databind was found in build.gradle It can be fixed by updating the version of the library in your project and rebuilding it.
```