### PR TITLE
[FIX] Removed collectionLinks build reference in webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,6 @@ module.exports = {
   },
   entry: {
     adminOnly: './src/main/webapp/adminOnly/AdminOnly.js',
-    collectionLinks: './src/main/webapp/collectionLinks/index.js',
     consentGroup: './src/main/webapp/consentGroup/index.js',
     footer: './src/main/webapp/components/footer.js',
     infoLink: './src/main/webapp/infoLink/index.js',


### PR DESCRIPTION
## Addresses
CI error message:
https://circleci.com/gh/broadinstitute/orsp-pub/4333

## Changes
Removed line to build collectionLinks which are no longer exists in the project.

## Testing
Describe for the reviewer how to test the specifics of this PR, both positive and negative cases.

---

- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Get a thumb from Belatrix
- [ ] **Submitter**: Get a thumb from @rushtong
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
