### PR TITLE
use replace and fix typo

### DIFF
--- a/src/main/webapp/projectContainer/ConsentGroups.js
+++ b/src/main/webapp/projectContainer/ConsentGroups.js
@@ -143,7 +143,7 @@ const ConsentGroups = hh(class ConsentGroups extends Component {
   handleSuccessNotification = () => {
     const urlParams = new URLSearchParams(window.location.search);
     if (urlParams.has('new') && urlParams.get('tab') === 'consent-groups') {
-      history.pushState({}, null, window.location.href.split('&')[0]);
+      history.pushState({}, null, window.location.href.replace('&new',''));
       setTimeout(this.clearAlertMessage, 8000, null);
       this.props.updateContent();
       this.setState(prev => {

--- a/src/main/webapp/qaReport/QaReport.js
+++ b/src/main/webapp/qaReport/QaReport.js
@@ -70,7 +70,7 @@ const QaReport = hh(class QaReport extends Component {
       this.props.hideSpinner()
       })
     } catch(error) {
-      this.hideSpinner();
+      this.props.hideSpinner();
       this.setState(() => { throw error });
     }
   };


### PR DESCRIPTION
## Addresses
[BTRX-782](https://broadinstitute.atlassian.net/browse/BTRX-782): ORSP: Redirection after adding new Sample Data Cohort is nor working as expected
## Changes
- Use replace instead of split. Split removes the url param tab indicator.
- Fix hideSpinner access.

## Testing
- Create a new Sample Data Cohort for an existing project. After that, the user should be redirected to Sample/Data Cohorts tab. The tab param should remain after the  "&new" flag is removed.
- If there is an Error while loading data for QA Events Reports, the spinner should hide and redirect to error page.
---

- [x] **Submitter**: Verify all tests go green, including CI tests
- [x] **Submitter**: Get a thumb from Belatrix
- [x] **Submitter**: Get a thumb from @rushtong
- [x] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [x] **Submitter**: Delete branch after merge
