### PR TITLE
BTRX - 776 - Unify Legacy / New Issue's statuses

### DIFF
--- a/grails-app/controllers/org/broadinstitute/orsp/SearchController.groovy
+++ b/grails-app/controllers/org/broadinstitute/orsp/SearchController.groovy
@@ -160,7 +160,7 @@ class SearchController implements UserInfo {
                         linkDisabled: permissionService.userHasIssueAccess(it.reporter, it.extraProperties, userName, isAdmin, isViewer),
                         title: it.summary,
                         type: it.type,
-                        status: it.approvalStatus != "Legacy" ? it.approvalStatus : it.status,
+                        status: it.getApprovalStatus(),
                         updated: it.updateDate ? format.format(it.updateDate): "",
                         expiration: it.expirationDate ? format.format(it.expirationDate) : "",
                         projectAccessContact: it.accessContacts

--- a/grails-app/domain/org/broadinstitute/orsp/Issue.groovy
+++ b/grails-app/domain/org/broadinstitute/orsp/Issue.groovy
@@ -57,8 +57,8 @@ class Issue implements LogicalDelete<Issue> {
     }
 
     transient isFlagSet(name) { getExtraProperties().find { (it.name == name) }?.value == "Yes" ?: false }
-    
-    String getApprovalStatus() { approvalStatus != IssueStatus.Legacy.name ? approvalStatus : status }
+
+    transient String getApprovalStatus() { approvalStatus != IssueStatus.Legacy.name ? approvalStatus : status }
 
     // General Data
     transient String getSubjectProtection() { getExtraProperties().find { it.name == IssueExtraProperty.SUBJECT_PROTECTION }?.value }

--- a/grails-app/domain/org/broadinstitute/orsp/Issue.groovy
+++ b/grails-app/domain/org/broadinstitute/orsp/Issue.groovy
@@ -57,6 +57,8 @@ class Issue implements LogicalDelete<Issue> {
     }
 
     transient isFlagSet(name) { getExtraProperties().find { (it.name == name) }?.value == "Yes" ?: false }
+    
+    String getApprovalStatus() { approvalStatus != IssueStatus.Legacy.name ? approvalStatus : status }
 
     // General Data
     transient String getSubjectProtection() { getExtraProperties().find { it.name == IssueExtraProperty.SUBJECT_PROTECTION }?.value }

--- a/grails-app/utils/org/broadinstitute/orsp/utils/UtilityClass.groovy
+++ b/grails-app/utils/org/broadinstitute/orsp/utils/UtilityClass.groovy
@@ -8,7 +8,6 @@ import org.broadinstitute.orsp.ConsentCollectionLink
 import org.broadinstitute.orsp.Event
 import org.broadinstitute.orsp.Funding
 import org.broadinstitute.orsp.Issue
-import org.broadinstitute.orsp.IssueStatus
 import org.broadinstitute.orsp.QueryService
 import org.broadinstitute.orsp.SampleCollection
 import org.broadinstitute.orsp.StatusEventDTO
@@ -79,7 +78,7 @@ class UtilityClass {
                         type: issue.type,
                         projectKey: issue.projectKey,
                         summary: issue.summary,
-                        status:  issue.approvalStatus == IssueStatus.Legacy.name ? issue.status : issue.approvalStatus,
+                        status:  issue.getApprovalStatus(),
                         issueStatus: issue.status,
                         reviewCategory: StringUtils.isNotEmpty(reviewCategory) ? reviewCategory : '',
                         reporter       : issue.reporter,
@@ -99,7 +98,7 @@ class UtilityClass {
                     type           : statusEvent.issue.type,
                     projectKey     : statusEvent.issue.projectKey,
                     summary        : statusEvent.issue.summary,
-                    status         : statusEvent.issue.approvalStatus == IssueStatus.Legacy.name ? statusEvent.issue.status : statusEvent.issue.approvalStatus,
+                    status         : statusEvent.issue.getApprovalStatus(),
                     reporter       : statusEvent.issue.reporter,
                     requestDate    : statusEvent.issue.requestDate,
                     attachments    : statusEvent.issue.attachments,

--- a/src/main/groovy/org/broadinstitute/orsp/IssueSearchItemDTO.groovy
+++ b/src/main/groovy/org/broadinstitute/orsp/IssueSearchItemDTO.groovy
@@ -112,4 +112,6 @@ class IssueSearchItemDTO {
         }
         resultDTO
     }
+
+    String getApprovalStatus() { approvalStatus != IssueStatus.Legacy.name ? approvalStatus : status }
 }

--- a/src/main/webapp/main/Main.js
+++ b/src/main/webapp/main/Main.js
@@ -47,7 +47,7 @@ class Main extends Component {
         prev.status.type = get(elementInfo, 'issue.type', '');
         prev.status.projectKey = get(elementInfo, 'issue.projectKey', '');
         prev.status.summary = get(elementInfo, 'issue.summary', '');
-        prev.status.status = issueStatus !== LEGACY  && issueStatus ? issueStatus : get(elementInfo, 'issue.status', '') ;
+        prev.status.status = issueStatus !== LEGACY  && issueStatus ? issueStatus : get(elementInfo, 'issue.status', '');
         prev.status.actor = get(elementInfo, 'extraProperties.actor', '');
         prev.status.projectReviewApproved = get(elementInfo, 'extraProperties.projectReviewApproved', '');
         prev.status.attachmentsApproved = get(elementInfo, 'attachmentsApproved', '');

--- a/src/main/webapp/main/Main.js
+++ b/src/main/webapp/main/Main.js
@@ -47,7 +47,7 @@ class Main extends Component {
         prev.status.type = get(elementInfo, 'issue.type', '');
         prev.status.projectKey = get(elementInfo, 'issue.projectKey', '');
         prev.status.summary = get(elementInfo, 'issue.summary', '');
-        prev.status.status = issueStatus !== LEGACY ? issueStatus : get(elementInfo, 'issue.status', '') ;
+        prev.status.status = issueStatus !== LEGACY  && issueStatus ? issueStatus : get(elementInfo, 'issue.status', '') ;
         prev.status.actor = get(elementInfo, 'extraProperties.actor', '');
         prev.status.projectReviewApproved = get(elementInfo, 'extraProperties.projectReviewApproved', '');
         prev.status.attachmentsApproved = get(elementInfo, 'attachmentsApproved', '');

--- a/src/main/webapp/main/Main.js
+++ b/src/main/webapp/main/Main.js
@@ -7,6 +7,8 @@ import get from 'lodash/get';
 import { isEmpty } from "../util/Utils";
 import './Main.css';
 
+const LEGACY = 'Legacy';
+
 class Main extends Component {
 
   _isMounted = false;
@@ -40,11 +42,12 @@ class Main extends Component {
 
   initStatusBoxInfo = (elementInfo) => {
     if (this._isMounted) {
+      const issueStatus = get(elementInfo, 'issue.approvalStatus', '');
       this.setState(prev => {
         prev.status.type = get(elementInfo, 'issue.type', '');
         prev.status.projectKey = get(elementInfo, 'issue.projectKey', '');
         prev.status.summary = get(elementInfo, 'issue.summary', '');
-        prev.status.status = get(elementInfo, 'issue.approvalStatus', '');
+        prev.status.status = issueStatus !== LEGACY ? issueStatus : get(elementInfo, 'issue.status', '') ;
         prev.status.actor = get(elementInfo, 'extraProperties.actor', '');
         prev.status.projectReviewApproved = get(elementInfo, 'extraProperties.projectReviewApproved', '');
         prev.status.attachmentsApproved = get(elementInfo, 'attachmentsApproved', '');


### PR DESCRIPTION
## Addresses
[BTRX-776](https://broadinstitute.atlassian.net/browse/BTRX-776): ORSP: Unify Legacy / New Issue's statuses
## Changes
- Change in Issue's getter for approval Status
- Change in Issue Search DTO getter for approval Status
- Main component is receiving the entire Issue project. Status logic has been handled in this component.

## Testing
- There shoulnd't be any `Legacy` status in Search result table. 
- If an old status is displayed for some project in Search result, this same result should appear in Project's Review status box. Later if this status changes to a new one, this should be reflected in Search table, Preview status header, QA Event Report and any other place where this status is displayed.
---

- [x] **Submitter**: Verify all tests go green, including CI tests
- [x] **Submitter**: Get a thumb from Belatrix
- [x] **Submitter**: Get a thumb from @rushtong
- [x] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [x] **Submitter**: Delete branch after merge
