### PR TITLE
BTRX - 783 - NPE on Sign Out

### DIFF
--- a/grails-app/controllers/org/broadinstitute/orsp/AuthenticatedController.groovy
+++ b/grails-app/controllers/org/broadinstitute/orsp/AuthenticatedController.groovy
@@ -328,7 +328,7 @@ class AuthenticatedController implements Interceptor, UserInfo, ExceptionHandler
     }
 
     def issueIsForbidden(issue) {
-        getUser() ? permissionService.issueIsForbidden(issue, getUser().userName, isAdmin(), isViewer()) : null
+        getUser() ? permissionService.issueIsForbidden(issue, getUser().userName, isAdmin(), isViewer()) : false
     }
 
     def redirectToMainContainer() {

--- a/grails-app/controllers/org/broadinstitute/orsp/AuthenticatedController.groovy
+++ b/grails-app/controllers/org/broadinstitute/orsp/AuthenticatedController.groovy
@@ -328,7 +328,7 @@ class AuthenticatedController implements Interceptor, UserInfo, ExceptionHandler
     }
 
     def issueIsForbidden(issue) {
-        return permissionService.issueIsForbidden(issue, getUser().userName, isAdmin(), isViewer())
+        getUser() ? permissionService.issueIsForbidden(issue, getUser().userName, isAdmin(), isViewer()) : null
     }
 
     def redirectToMainContainer() {


### PR DESCRIPTION
## Addresses
[BTRX-783](https://broadinstitute.atlassian.net/browse/BTRX-783): NPE on Sign Out

## Changes
- `issueIsForbidden` method in `AuthenticatedController` threw a Groovy handled error to the Ui since this is trying to access userName of a null object, returned by `getUser()` called in the parameters of `permissionService.issueIsForbidden`.

## Testing
- Log in with valid credentials
- Go to a Project
- Sign Out, There shouldn't be any error message on the ui
---

- [x] **Submitter**: Verify all tests go green, including CI tests
- [x] **Submitter**: Get a thumb from Belatrix
- [x] **Submitter**: Get a thumb from @rushtong
- [x] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [x] **Submitter**: Delete branch after merge
