### PR TITLE
BTRX - 789 - My Task List and Project List Download buttons not working

### DIFF
--- a/src/main/webapp/issueList/IssueList.js
+++ b/src/main/webapp/issueList/IssueList.js
@@ -3,7 +3,7 @@ import { div, h, h1, hh } from 'react-hyperscript-helpers';
 import { TableComponent } from '../components/TableComponent';
 import { Project } from '../util/ajax';
 import { formatDataPrintableFormat } from '../util/TableUtil';
-import { printData } from '../util/Utils';
+import { exportData } from '../util/Utils';
 import { Link } from 'react-router-dom';
 import isNil from 'lodash/isNil';
 import '../index.css';
@@ -202,7 +202,7 @@ const IssueList = hh(class IssueList extends Component {
     let issues = formatDataPrintableFormat(this.state.issues, cols);
     const tableColumnsWidth = [100, 100, '*', 80, '*', '*', '*', '*', '*'];
     const titleText = "";
-    printData(issues, titleText, '', tableColumnsWidth, 'A3', 'landscape');
+    exportData(issues, titleText, '', tableColumnsWidth, 'A3', 'landscape');
   };
 
   render() {

--- a/src/main/webapp/issueList/IssueList.js
+++ b/src/main/webapp/issueList/IssueList.js
@@ -200,9 +200,8 @@ const IssueList = hh(class IssueList extends Component {
   printContent = () => {
     let cols = columns.filter(el => el.dataField !== 'id');
     let issues = formatDataPrintableFormat(this.state.issues, cols);
-    const tableColumnsWidth = [100, 100, '*', 80, '*', '*', '*', '*', '*'];
-    const titleText = "";
-    exportData(issues, titleText, '', tableColumnsWidth, 'A3', 'landscape');
+    const tableColumnsWidth = [100, 100, '*', 80, '*', '*'];
+    exportData(issues, '', issues, tableColumnsWidth, '');
   };
 
   render() {

--- a/src/main/webapp/util/TableUtil.js
+++ b/src/main/webapp/util/TableUtil.js
@@ -42,7 +42,7 @@ export const formatExcelData = (data, columns, hide) => {
   if (!isEmpty(data) && !isEmpty(columns)) {
     data.forEach(el => {
       let newEl = {};
-      Object.keys(el).filter(elem => (elem !== 'id' && !hide.includes(elem) )).forEach(key => {
+      Object.keys(el).filter(elem => (elem !== 'id' || (hide && !hide.includes(elem)) )).forEach(key => {
         newEl[key] = parseDataElements(el, key);
       });
       rows.push(newEl);


### PR DESCRIPTION
## Addresses
[BTRX-789](https://broadinstitute.atlassian.net/browse/BTRX-789): My Task List and Project List Download buttons not working

## Changes
- In some PR merge transition `printData` changed its name to `exportData` and it wasn't renamed on this component.
- In some cases hide array is undefined since its not being passed through the component props, and extra condition is added for this reason.

## Testing
- Print and Excel buttons should work as expected in **My Task List** and **My Project List**. Both links can be accessed in the index page (or landing page)

---

- [x] **Submitter**: Verify all tests go green, including CI tests
- [x] **Submitter**: Get a thumb from Belatrix
- [x] **Submitter**: Get a thumb from @rushtong
- [x] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [x] **Submitter**: Delete branch after merge
