### PR TITLE
BTRX - 790 - Fix legacy institutional resource

### DIFF
--- a/src/main/webapp/components/InstitutionalSource.js
+++ b/src/main/webapp/components/InstitutionalSource.js
@@ -24,12 +24,14 @@ export const InstitutionalSource = hh(class InstitutionalSource extends Componen
     }
   }
 
+  checkEmptySrc(elementPostition) {
+    return (get(this.props.institutionalSources[elementPostition], 'future.name') !== '' && get(this.props.institutionalSources[elementPostition], 'future.country') !== '')
+      || (!isEmpty(this.props.institutionalSources[elementPostition].current.name) && !isEmpty(this.props.institutionalSources[elementPostition].current.country));
+  }
+
   addInstitutionalSources() {
     if (this.props.edit) {
-      if (!isEmpty(this.props.institutionalSources) &&
-         (get(this.props.institutionalSources,'[0].future.name') !== '' && get(this.props.institutionalSources,'[0].future.country') !== '')
-          || (!isEmpty(this.props.institutionalSources[0].current.name) && !isEmpty(this.props.institutionalSources[0].current.country ))
-      ) {
+      if (!isEmpty(this.props.institutionalSources) && this.checkEmptySrc(0)) {
         this.setState(prev => {
           let institutionalSources = this.props.institutionalSources;
           institutionalSources.splice(0, 0, {
@@ -42,7 +44,7 @@ export const InstitutionalSource = hh(class InstitutionalSource extends Componen
         }, () => {
           this.props.updateInstitutionalSource(this.state.institutionalSources)
         });
-      } else {
+      } else if (this.checkEmptySrc(0) && this.checkEmptySrc(1)) {
         this.props.updateInstitutionalSource([{
           current: { name: null, country: null },
           future: { name: '', country: '' }
@@ -167,7 +169,7 @@ export const InstitutionalSource = hh(class InstitutionalSource extends Componen
                       currentValue: this.props.edit ? rd.current.name : rd.name,
                       required: true,
                       onChange: this.handleInstitutionalChange,
-                      error: this.props.edit ? this.getError(index, "name") : this.props.errorName && index === 0 && this.isEmpty(rd.name ===''),
+                      error: this.props.edit ? this.getError(index, "name") : this.props.errorName && index === 0 && this.isEmpty(rd.name),
                       disabled: (index > 0) && !this.props.edit,
                       errorMessage: this.props.errorMessage,
                       readOnly: this.props.readOnly,

--- a/src/main/webapp/components/InstitutionalSource.js
+++ b/src/main/webapp/components/InstitutionalSource.js
@@ -3,11 +3,6 @@ import { div, h, hh, hr, label } from 'react-hyperscript-helpers';
 import { InputFieldText } from './InputFieldText';
 import { Btn } from './Btn';
 
-const EMPTY_EDIT_OBJECT = {
-  current: { name: null, country: null },
-  future: { name: '', country: '' }
-};
-
 export const InstitutionalSource = hh(class InstitutionalSource extends Component {
 
   constructor(props) {
@@ -34,7 +29,11 @@ export const InstitutionalSource = hh(class InstitutionalSource extends Componen
         || this.props.institutionalSources[0] && (this.props.institutionalSources[0].current.name && this.props.institutionalSources[0].current.country )) {
         this.setState(prev => {
           let institutionalSources = this.props.institutionalSources;
-          institutionalSources.splice(0, 0, EMPTY_EDIT_OBJECT);
+          institutionalSources.splice(0, 0, {
+            current: { name: null, country: null },
+            future: { name: '', country: '' }
+          });
+          // console.log("institutional sources -> ", institutionalSources)
           prev.institutionalSources = institutionalSources;
           this.props.error && this.props.edit ? this.props.errorHandler() : prev.error = false;
           return prev;
@@ -42,7 +41,10 @@ export const InstitutionalSource = hh(class InstitutionalSource extends Componen
           this.props.updateInstitutionalSource(this.state.institutionalSources)
         });
       } else {
-        this.props.updateInstitutionalSource([EMPTY_EDIT_OBJECT])
+        this.props.updateInstitutionalSource([{
+          current: { name: null, country: null },
+          future: { name: '', country: '' }
+        }])
       }
     } else {
       // For new Projects

--- a/src/main/webapp/components/InstitutionalSource.js
+++ b/src/main/webapp/components/InstitutionalSource.js
@@ -163,7 +163,7 @@ export const InstitutionalSource = hh(class InstitutionalSource extends Componen
                       currentValue: this.props.edit ? rd.current.name : rd.name,
                       required: true,
                       onChange: this.handleInstitutionalChange,
-                      error: this.props.edit ? this.getError(index, "name") : this.props.errorName && index === 0,
+                      error: this.props.edit ? this.getError(index, "name") : this.props.errorName && index === 0 && this.isEmpty(rd.name ===''),
                       disabled: (index > 0) && !this.props.edit,
                       errorMessage: this.props.errorMessage,
                       readOnly: this.props.readOnly,
@@ -180,7 +180,7 @@ export const InstitutionalSource = hh(class InstitutionalSource extends Componen
                       currentValue: this.props.edit ? rd.current.country : rd.country,
                       required: true,
                       onChange: this.handleInstitutionalChange,
-                      error: this.props.edit ? this.getError(index, "country") : this.props.errorCountry && index === 0,
+                      error: this.props.edit ? this.getError(index, "country") : this.props.errorCountry && index === 0 && this.isEmpty(rd.country),
                       disabled: (index > 0) && !this.props.edit,
                       errorMessage: this.props.errorMessage,
                       readOnly: this.props.readOnly

--- a/src/main/webapp/components/InstitutionalSource.js
+++ b/src/main/webapp/components/InstitutionalSource.js
@@ -2,6 +2,8 @@ import { Component, Fragment } from 'react';
 import { div, h, hh, hr, label } from 'react-hyperscript-helpers';
 import { InputFieldText } from './InputFieldText';
 import { Btn } from './Btn';
+import get from 'lodash/get';
+import isEmpty from 'lodash/isEmpty';
 
 export const InstitutionalSource = hh(class InstitutionalSource extends Component {
 
@@ -24,9 +26,10 @@ export const InstitutionalSource = hh(class InstitutionalSource extends Componen
 
   addInstitutionalSources() {
     if (this.props.edit) {
-      // Only for edit / review
-      if (this.props.institutionalSources[0] && (this.props.institutionalSources[0].future.name !== '' && this.props.institutionalSources[0].future.country !== '')
-        || this.props.institutionalSources[0] && (this.props.institutionalSources[0].current.name && this.props.institutionalSources[0].current.country )) {
+      if (!isEmpty(this.props.institutionalSources) &&
+         (get(this.props.institutionalSources,'[0].future.name') !== '' && get(this.props.institutionalSources,'[0].future.country') !== '')
+          || (!isEmpty(this.props.institutionalSources[0].current.name) && !isEmpty(this.props.institutionalSources[0].current.country ))
+      ) {
         this.setState(prev => {
           let institutionalSources = this.props.institutionalSources;
           institutionalSources.splice(0, 0, {

--- a/src/main/webapp/components/InstitutionalSource.js
+++ b/src/main/webapp/components/InstitutionalSource.js
@@ -1,7 +1,12 @@
 import { Component, Fragment } from 'react';
-import { input, hh, h, div, p, hr, small, label } from 'react-hyperscript-helpers';
+import { div, h, hh, hr, label } from 'react-hyperscript-helpers';
 import { InputFieldText } from './InputFieldText';
 import { Btn } from './Btn';
+
+const EMPTY_EDIT_OBJECT = {
+  current: { name: null, country: null },
+  future: { name: '', country: '' }
+};
 
 export const InstitutionalSource = hh(class InstitutionalSource extends Component {
 
@@ -25,20 +30,19 @@ export const InstitutionalSource = hh(class InstitutionalSource extends Componen
   addInstitutionalSources() {
     if (this.props.edit) {
       // Only for edit / review
-      if ((this.props.institutionalSources[0].future.name !== '' && this.props.institutionalSources[0].future.country !== '')
-        || this.props.institutionalSources[0].current.name && this.props.institutionalSources[0].current.country ) {
+      if (this.props.institutionalSources[0] && (this.props.institutionalSources[0].future.name !== '' && this.props.institutionalSources[0].future.country !== '')
+        || this.props.institutionalSources[0] && (this.props.institutionalSources[0].current.name && this.props.institutionalSources[0].current.country )) {
         this.setState(prev => {
           let institutionalSources = this.props.institutionalSources;
-          institutionalSources.splice(0, 0, {
-            current: { name: null, country: null },
-            future: { name: '', country: '' }
-          });
+          institutionalSources.splice(0, 0, EMPTY_EDIT_OBJECT);
           prev.institutionalSources = institutionalSources;
           this.props.error && this.props.edit ? this.props.errorHandler() : prev.error = false;
           return prev;
         }, () => {
           this.props.updateInstitutionalSource(this.state.institutionalSources)
         });
+      } else {
+        this.props.updateInstitutionalSource([EMPTY_EDIT_OBJECT])
       }
     } else {
       // For new Projects

--- a/src/main/webapp/components/InstitutionalSource.js
+++ b/src/main/webapp/components/InstitutionalSource.js
@@ -33,7 +33,6 @@ export const InstitutionalSource = hh(class InstitutionalSource extends Componen
             current: { name: null, country: null },
             future: { name: '', country: '' }
           });
-          // console.log("institutional sources -> ", institutionalSources)
           prev.institutionalSources = institutionalSources;
           this.props.error && this.props.edit ? this.props.errorHandler() : prev.error = false;
           return prev;


### PR DESCRIPTION
## Addresses
[BTRX-790](https://broadinstitute.atlassian.net/browse/BTRX-790): Institutional Sources not working on Legacy Sample/Data Cohorts
## Changes
- Added an extra condition for legacy projects where `institutionalSources` does not exist on the database.

## Testing
- Open a legacy consent group or a consent group that doesn't have any institutional Source stored in the data base, add a new element, the should allow to do this.
- Create a new consent group, its functionality shouldn't have changed

---

- [x] **Submitter**: Verify all tests go green, including CI tests
- [x] **Submitter**: Get a thumb from Belatrix
- [x] **Submitter**: Get a thumb from @rushtong
- [x] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [x] **Submitter**: Delete branch after merge
