### PR TITLE
BTRX - 791 - Sample Data Cohorts existing name verification is not working

### DIFF
--- a/grails-app/controllers/org/broadinstitute/orsp/UrlMappings.groovy
+++ b/grails-app/controllers/org/broadinstitute/orsp/UrlMappings.groovy
@@ -50,6 +50,7 @@ class UrlMappings {
         '/api/consent-group/upload-modal'(controller: 'consentGroup', action: 'loadModalWindow', method: 'GET')
         '/api/consent-groups'(controller: 'consentGroup', action: 'projectConsentGroups', method: 'GET')
         '/api/consent-group/get-project-consent-groups'(controller:'newConsentGroup', action:'getProjectConsentGroups', method: 'GET')
+        '/api/consent-groups/matching-name'(controller: 'newConsentGroup', action: 'matchConsentName', method: 'GET')
 
         // File related end points
         '/api/files-helper/attach-document'(controller: 'fileHelper', action: 'attachDocument', method: 'POST')

--- a/grails-app/controllers/org/broadinstitute/orsp/api/NewConsentGroupController.groovy
+++ b/grails-app/controllers/org/broadinstitute/orsp/api/NewConsentGroupController.groovy
@@ -16,7 +16,6 @@ import org.broadinstitute.orsp.Issue
 import org.broadinstitute.orsp.IssueExtraProperty
 import org.broadinstitute.orsp.IssueType
 import org.broadinstitute.orsp.PersistenceService
-import org.broadinstitute.orsp.QueryOptions
 import org.broadinstitute.orsp.User
 import org.broadinstitute.orsp.utils.IssueUtils
 import org.broadinstitute.orsp.utils.UtilityClass
@@ -237,7 +236,7 @@ class NewConsentGroupController extends AuthenticatedController {
 
     def matchConsentName() {
         try {
-            render(params.consentName ? !queryService.findIssueByName(params.consentName).isEmpty(): false as JSON)
+            render(params.consentName ? queryService.matchingIssueNamesCount(params.consentName) > 0 : false)
         } catch(Exception error) {
             handleException(error)
         }

--- a/grails-app/controllers/org/broadinstitute/orsp/api/NewConsentGroupController.groovy
+++ b/grails-app/controllers/org/broadinstitute/orsp/api/NewConsentGroupController.groovy
@@ -16,6 +16,7 @@ import org.broadinstitute.orsp.Issue
 import org.broadinstitute.orsp.IssueExtraProperty
 import org.broadinstitute.orsp.IssueType
 import org.broadinstitute.orsp.PersistenceService
+import org.broadinstitute.orsp.QueryOptions
 import org.broadinstitute.orsp.User
 import org.broadinstitute.orsp.utils.IssueUtils
 import org.broadinstitute.orsp.utils.UtilityClass
@@ -234,4 +235,11 @@ class NewConsentGroupController extends AuthenticatedController {
         render(response)
     }
 
+    def matchConsentName() {
+        try {
+            render(params.consentName ? !queryService.findIssueByName(params.consentName).isEmpty(): false as JSON)
+        } catch(Exception error) {
+            handleException(error)
+        }
+    }
 }

--- a/grails-app/services/org/broadinstitute/orsp/QueryService.groovy
+++ b/grails-app/services/org/broadinstitute/orsp/QueryService.groovy
@@ -1078,16 +1078,12 @@ class QueryService implements Status {
         results
     }
 
-    List<Issue> findIssueByName (String issueName) {
+    Long matchingIssueNamesCount(String issueName) {
         final session = sessionFactory.currentSession
-        final String query = 'select * from issue where summary = :issueName'
-        final sqlQuery = session.createSQLQuery(query)
-        final results = sqlQuery.with {
-            addEntity(Issue)
-            setString('issueName', issueName)
-            list()
-        }
-        results
+        final String query = 'select count(id) from issue where summary = :issueName'
+        SQLQuery sqlQuery = session.createSQLQuery(query)
+        sqlQuery.setString('issueName', issueName)
+        sqlQuery.uniqueResult() as Long
     }
 
     PaginatedResponse findIssueByProjectType(String type, PaginationParams pagination) {

--- a/grails-app/services/org/broadinstitute/orsp/QueryService.groovy
+++ b/grails-app/services/org/broadinstitute/orsp/QueryService.groovy
@@ -1078,6 +1078,18 @@ class QueryService implements Status {
         results
     }
 
+    List<Issue> findIssueByName (String issueName) {
+        final session = sessionFactory.currentSession
+        final String query = 'select * from issue where summary = :issueName'
+        final sqlQuery = session.createSQLQuery(query)
+        final results = sqlQuery.with {
+            addEntity(Issue)
+            setString('issueName', issueName)
+            list()
+        }
+        results
+    }
+
     PaginatedResponse findIssueByProjectType(String type, PaginationParams pagination) {
         String orderColumn = getIssueOrderColumn(pagination.orderColumn)
         SessionFactory sessionFactory = grailsApplication.getMainContext().getBean('sessionFactory')

--- a/src/main/webapp/components/Wizard.js
+++ b/src/main/webapp/components/Wizard.js
@@ -50,7 +50,6 @@ export const Wizard = hh(class Wizard extends Component {
 
   goStep = (n) => async (e) => {
     e.preventDefault();
-    // await this.props.isValid(n, null)
     this.setState(prev => {
       prev.currentStepIndex = n;
       prev.readyToSubmit = this.props.showSubmit(n);

--- a/src/main/webapp/components/Wizard.js
+++ b/src/main/webapp/components/Wizard.js
@@ -33,9 +33,9 @@ export const Wizard = hh(class Wizard extends Component {
     })
   };
 
-  nextStep = (e) => {
+  nextStep = async (e) => {
     e.preventDefault();
-    if (this.props.isValid(this.state.currentStepIndex, null)) {
+    if (await this.props.isValid(this.state.currentStepIndex, null)) {
       this.setState(prev => {
         prev.showError = true;
         prev.currentStepIndex = prev.currentStepIndex === this.props.children.length - 1 ? 0 : prev.currentStepIndex + 1;

--- a/src/main/webapp/components/Wizard.js
+++ b/src/main/webapp/components/Wizard.js
@@ -48,8 +48,9 @@ export const Wizard = hh(class Wizard extends Component {
     }
   };
 
-  goStep = (n) => (e) => {
+  goStep = (n) => async (e) => {
     e.preventDefault();
+    // await this.props.isValid(n, null)
     this.setState(prev => {
       prev.currentStepIndex = n;
       prev.readyToSubmit = this.props.showSubmit(n);

--- a/src/main/webapp/consentGroup/NewConsentGroup.js
+++ b/src/main/webapp/consentGroup/NewConsentGroup.js
@@ -354,9 +354,9 @@ const NewConsentGroup = hh(class NewConsentGroup extends Component {
         prev.errors.institutionalSourcesCountry = institutionalSourcesCountry;
         prev.errors.noConsentFormReason = noConsentFormReason;
         prev.errors.isValid = isValid;
-        if (isValid) {
-          prev.generalError = false;
-        }
+        // if (isValid) {
+          prev.generalError = isValid;
+        // }
         return prev;
       });
     }

--- a/src/main/webapp/consentGroup/NewConsentGroup.js
+++ b/src/main/webapp/consentGroup/NewConsentGroup.js
@@ -354,9 +354,7 @@ const NewConsentGroup = hh(class NewConsentGroup extends Component {
         prev.errors.institutionalSourcesCountry = institutionalSourcesCountry;
         prev.errors.noConsentFormReason = noConsentFormReason;
         prev.errors.isValid = isValid;
-        // if (isValid) {
-          prev.generalError = isValid;
-        // }
+        prev.generalError = isValid;
         return prev;
       });
     }

--- a/src/main/webapp/consentGroup/NewConsentGroup.js
+++ b/src/main/webapp/consentGroup/NewConsentGroup.js
@@ -8,6 +8,7 @@ import { CONSENT_DOCUMENTS } from '../util/DocumentType';
 import { NewLinkCohortData } from './NewLinkCohortData';
 import * as qs from 'query-string';
 import LoadingWrapper from '../components/LoadingWrapper';
+import get from 'lodash/get';
 
 const LAST_STEP = 1;
 const NEXT_INDICATOR = 0;
@@ -272,12 +273,9 @@ const NewConsentGroup = hh(class NewConsentGroup extends Component {
   }
 
   async consentGroupNameExists() {
-    let exists = false;
-    if (!isEmpty(this.state.generalDataFormData.consentGroupName)) {
-      const result = await ConsentGroup.getMatchingConsentByName(this.state.generalDataFormData.consentGroupName);
-      exists = result.data;
-    }
-    return exists;
+    return !isEmpty(this.state.generalDataFormData.consentGroupName)
+      ? get(await ConsentGroup.getMatchingConsentByName(this.state.generalDataFormData.consentGroupName), 'data', false)
+      : false;
   }
 
   isConsentFormUploaded() {

--- a/src/main/webapp/consentGroup/NewConsentGroupGeneralData.js
+++ b/src/main/webapp/consentGroup/NewConsentGroupGeneralData.js
@@ -131,6 +131,7 @@ export const NewConsentGroupGeneralData = hh(class NewConsentGroupGeneralData ex
           this.props.errors.collaboratingInstitution ||
           this.props.errors.primaryContact ||
           this.props.errors.requireMta ||
+          this.props.errors.consentGroupName ||
           this.props.errors.institutionalSourcesName ||
           this.props.errors.institutionalSourcesCountry ||
           this.props.errors.startDate ||

--- a/src/main/webapp/consentGroup/NewLinkCohortData.js
+++ b/src/main/webapp/consentGroup/NewLinkCohortData.js
@@ -62,7 +62,7 @@ export const NewLinkCohortData = hh(class NewLinkCohortData extends Component {
               currentStep: this.props.currentStep,
               user: this.props.user,
               updateForm: this.props.updateInfoSecurityFormData,
-              generalError: this.props.generalError,
+              generalError: this.props.generalError && this.props.showErrorInfoSecurity,
               submitError: this.props.submitError,
               handleSecurityValidity: this.props.handleInfoSecurityValidity,
               securityInfoData: this.props.securityInfoData,

--- a/src/main/webapp/consentGroupReview/ConsentGroupReview.js
+++ b/src/main/webapp/consentGroupReview/ConsentGroupReview.js
@@ -111,7 +111,6 @@ const ConsentGroupReview = hh(class ConsentGroupReview extends Component {
       isEdited: false,
     };
     this.rejectConsentGroup = this.rejectConsentGroup.bind(this);
-    this.consentGroupNameExists = this.consentGroupNameExists.bind(this);
   }
 
   componentDidMount() {
@@ -674,7 +673,7 @@ const ConsentGroupReview = hh(class ConsentGroupReview extends Component {
   }
 
 
-   async consentGroupNameExists() {
+   consentGroupNameExists = async () =>  {
     const groupName = [this.state.formData.consentExtraProps.consent, this.state.formData.consentExtraProps.protocol].join(" / ");
     let exists = false;
     if (!isEmpty(this.state.formData.consentExtraProps.consent) && !isEmpty(this.state.formData.consentExtraProps.protocol)) {

--- a/src/main/webapp/consentGroupReview/ConsentGroupReview.js
+++ b/src/main/webapp/consentGroupReview/ConsentGroupReview.js
@@ -678,8 +678,7 @@ const ConsentGroupReview = hh(class ConsentGroupReview extends Component {
     const groupName = [this.state.formData.consentExtraProps.consent, this.state.formData.consentExtraProps.protocol].join(" / ");
     let exists = false;
     if (!isEmpty(this.state.formData.consentExtraProps.consent) && !isEmpty(this.state.formData.consentExtraProps.protocol)) {
-      const result = await ConsentGroup.getMatchingConsentByName(groupName);
-      exists = result.data;
+      exists = get(await ConsentGroup.getMatchingConsentByName(groupName), 'data', false);
       this.setState(prev => {
         prev.errors.consentGroupName = exists;
         return prev;

--- a/src/main/webapp/consentGroupReview/ConsentGroupReview.js
+++ b/src/main/webapp/consentGroupReview/ConsentGroupReview.js
@@ -680,12 +680,10 @@ const ConsentGroupReview = hh(class ConsentGroupReview extends Component {
     if (!isEmpty(this.state.formData.consentExtraProps.consent) && !isEmpty(this.state.formData.consentExtraProps.protocol)) {
       const result = await ConsentGroup.getMatchingConsentByName(groupName);
       exists = result.data;
-      // let consentGroupNameExists = groupName === this.state.formData.consentForm.summary ? false : this.state.existingGroupNames.indexOf(groupName) > -1;
       this.setState(prev => {
         prev.errors.consentGroupName = exists;
         return prev;
       });
-      // return consentGroupNameExists;
     }
     return exists;
   }

--- a/src/main/webapp/util/UrlConstants.js
+++ b/src/main/webapp/util/UrlConstants.js
@@ -34,6 +34,7 @@ export const UrlConstants = {
   allConsentGroupsUrl: context + '/api/consent-groups',
   collectionLinks: context + '/api/collection-links',
   exportConsent: context + '/api/consent/export',
+  matchingName: context + '/api/consent-groups/matching-name',
   // File related urls
   attachDocuments: context + '/api/files-helper/attach-document',
   attachedDocumentsUrl : context + '/api/files-helper/attached-documents',

--- a/src/main/webapp/util/ajax.js
+++ b/src/main/webapp/util/ajax.js
@@ -106,6 +106,10 @@ export const ConsentGroup = {
 
   exportConsent(id) {
     return axios.post(UrlConstants.exportConsent + '?id=' + id);
+  },
+
+  getMatchingConsentByName(consentName) {
+    return axios.get(UrlConstants.matchingName + '?consentName=' + consentName);
   }
 };
 


### PR DESCRIPTION
## Addresses
[BTRX-791](https://broadinstitute.atlassian.net/browse/BTRX-791): ORSP - Sample Data Cohorts existing name verification is not working

## Changes
- Changed the logic from obtaining the entire list of Consent group names an find if there's any matching name to make a single request to db to verify if there's any matching name for the given Sample Data Cohort.
- Add async operator for some methods in order to wait the name verification result
- Display general warning in general data step when name validation is triggered

## Testing
- Create a new Sample Data Cohort, use an existing name of another Sample Data Cohort already created. On focus out from the text field a warning should appear stating an already existing name. 
- The validation is made when the next button is pressed, and on Submit.
- The same validations are made in Sample Data Cohorts Review edit version.
---

- [x] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Get a thumb from Belatrix
- [ ] **Submitter**: Get a thumb from @rushtong
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
