### PR TITLE
BTRX - 798 & 797 - Create and Add Existing Sample Data Cohorts error

### DIFF
--- a/grails-app/controllers/org/broadinstitute/orsp/api/NewConsentGroupController.groovy
+++ b/grails-app/controllers/org/broadinstitute/orsp/api/NewConsentGroupController.groovy
@@ -87,7 +87,7 @@ class NewConsentGroupController extends AuthenticatedController {
                 consent.status = 201
                 render([message: consent] as JSON)
             } else {
-                Response response = Response.status(400)
+                Response response = response.status(400)
                 response.entity("Invalid project key")
                 render([message: response] as JSON)
             }

--- a/src/main/webapp/consentGroup/NewConsentGroup.js
+++ b/src/main/webapp/consentGroup/NewConsentGroup.js
@@ -14,9 +14,12 @@ const LAST_STEP = 1;
 const NewConsentGroup = hh(class NewConsentGroup extends Component {
 
   _isMounted = false;
+  projectKey = '';
 
   constructor(props) {
     super(props);
+    const params = new URLSearchParams(this.props.location.search);
+    this.projectKey = params.get('projectKey') != null ? params.get('projectKey') : component.projectKey;
     this.state = {
       user: {
         displayName: '',
@@ -125,7 +128,6 @@ const NewConsentGroup = hh(class NewConsentGroup extends Component {
         this.state.user.displayName,
         this.state.user.userName)
         .then(resp => {
-          console.log("redirect => ", '/project/main?projectKey=' + qs.parse(this.props.location.search).projectKey + '&tab=consent-groups&new');
           this.props.history.push('/project/main?projectKey=' + qs.parse(this.props.location.search).projectKey + '&tab=consent-groups&new');
           this.props.hideSpinner()
         }).catch(error => {
@@ -167,7 +169,7 @@ const NewConsentGroup = hh(class NewConsentGroup extends Component {
     let consentCollectionLink = {};
     // consent collection link info
     consentCollectionLink.sampleCollectionId = sampleCollectionId;
-    consentCollectionLink.projectKey = component.projectKey;
+    consentCollectionLink.projectKey = this.projectKey;
     consentCollectionLink.requireMta = this.state.linkFormData.requireMta;
     consentCollectionLink.startDate = this.parseDate(this.state.generalDataFormData.startDate);
     consentCollectionLink.onGoingProcess = this.state.generalDataFormData.onGoingProcess ;
@@ -196,7 +198,6 @@ const NewConsentGroup = hh(class NewConsentGroup extends Component {
   }
 
   getConsentGroup() {
-    const params = new URLSearchParams(this.props.location.search);
     // step 1
     let consentGroup = {};
     consentGroup.summary = this.state.generalDataFormData.consentGroupName;
@@ -204,7 +205,7 @@ const NewConsentGroup = hh(class NewConsentGroup extends Component {
     consentGroup.samples = this.getSampleCollections();
     let extraProperties = [];
 
-    extraProperties.push({ name: 'source', value: params.get('projectKey') != null ? params.get('projectKey') : component.projectKey });
+    extraProperties.push({ name: 'source', value: this.projectKey });
     extraProperties.push({ name: 'collInst', value: this.state.generalDataFormData.collaboratingInstitution });
     extraProperties.push({ name: 'collContact', value: this.state.generalDataFormData.primaryContact });
     extraProperties.push({ name: 'consent', value: this.state.generalDataFormData.investigatorLastName });
@@ -534,7 +535,7 @@ const NewConsentGroup = hh(class NewConsentGroup extends Component {
             updateForm: this.updateGeneralDataFormData,
             errors: this.state.errors,
             removeErrorMessage: this.removeErrorMessage,
-            projectKey: component.projectKey,
+            projectKey: this.projectKey,
             sampleCollectionList: this.state.sampleCollectionList,
             fileHandler: this.fileHandler,
             projectType: projectType,

--- a/src/main/webapp/consentGroup/NewConsentGroup.js
+++ b/src/main/webapp/consentGroup/NewConsentGroup.js
@@ -8,6 +8,7 @@ import { CONSENT_DOCUMENTS } from '../util/DocumentType';
 import { NewLinkCohortData } from './NewLinkCohortData';
 import * as qs from 'query-string';
 import LoadingWrapper from '../components/LoadingWrapper';
+import defaultTo from 'lodash/defaultTo';
 
 const LAST_STEP = 1;
 
@@ -19,7 +20,7 @@ const NewConsentGroup = hh(class NewConsentGroup extends Component {
   constructor(props) {
     super(props);
     const params = new URLSearchParams(this.props.location.search);
-    this.projectKey = params.get('projectKey') != null ? params.get('projectKey') : component.projectKey;
+    this.projectKey = defaultTo(params.get('projectKey'), component.projectKey);
     this.state = {
       user: {
         displayName: '',

--- a/src/main/webapp/consentGroup/NewConsentGroup.js
+++ b/src/main/webapp/consentGroup/NewConsentGroup.js
@@ -125,7 +125,8 @@ const NewConsentGroup = hh(class NewConsentGroup extends Component {
         this.state.user.displayName,
         this.state.user.userName)
         .then(resp => {
-          this.props.history.push('/project/main?projectKey=' + qs.parse(this.props.location.search).projectKey + '&tab=consent-groups&new', {tab: 'consent-groups'});
+          console.log("redirect => ", '/project/main?projectKey=' + qs.parse(this.props.location.search).projectKey + '&tab=consent-groups&new');
+          this.props.history.push('/project/main?projectKey=' + qs.parse(this.props.location.search).projectKey + '&tab=consent-groups&new');
           this.props.hideSpinner()
         }).catch(error => {
         console.error(error);
@@ -195,6 +196,7 @@ const NewConsentGroup = hh(class NewConsentGroup extends Component {
   }
 
   getConsentGroup() {
+    const params = new URLSearchParams(this.props.location.search);
     // step 1
     let consentGroup = {};
     consentGroup.summary = this.state.generalDataFormData.consentGroupName;
@@ -202,7 +204,7 @@ const NewConsentGroup = hh(class NewConsentGroup extends Component {
     consentGroup.samples = this.getSampleCollections();
     let extraProperties = [];
 
-    extraProperties.push({ name: 'source', value: component.projectKey });
+    extraProperties.push({ name: 'source', value: params.get('projectKey') != null ? params.get('projectKey') : component.projectKey });
     extraProperties.push({ name: 'collInst', value: this.state.generalDataFormData.collaboratingInstitution });
     extraProperties.push({ name: 'collContact', value: this.state.generalDataFormData.primaryContact });
     extraProperties.push({ name: 'consent', value: this.state.generalDataFormData.investigatorLastName });

--- a/src/main/webapp/linkWizard/LinkWizard.js
+++ b/src/main/webapp/linkWizard/LinkWizard.js
@@ -187,12 +187,13 @@ const LinkWizard = hh( class LinkWizard extends Component {
   };
 
   getConsentCollectionData = () => {
+    const params = new URLSearchParams(this.props.location.search);
     let consentCollectionLink = {};
     // consent group info
     consentCollectionLink.consentKey = this.state.consentGroup.key;
     // consent collection link info
     consentCollectionLink.sampleCollectionId = this.state.sampleCollection.value;
-    consentCollectionLink.projectKey = component.projectKey;
+    consentCollectionLink.projectKey = params.get('projectKey') != null ? params.get('projectKey') : component.projectKey;
     consentCollectionLink.requireMta = this.state.linkFormData.requireMta;
     // security
     consentCollectionLink.pii = this.state.securityInfoFormData.pii == "true" ? true : false;

--- a/src/main/webapp/linkWizard/LinkWizard.js
+++ b/src/main/webapp/linkWizard/LinkWizard.js
@@ -8,6 +8,7 @@ import { isEmpty } from '../util/Utils';
 import '../index.css';
 import * as qs from 'query-string';
 import LoadingWrapper from '../components/LoadingWrapper';
+import defaultTo from 'lodash/defaultTo';
 
 const LAST_STEP = 1;
 
@@ -19,7 +20,7 @@ const LinkWizard = hh( class LinkWizard extends Component {
   constructor(props) {
     super(props);
     const params = new URLSearchParams(this.props.location.search);
-    this.projectKey = params.get('projectKey') != null ? params.get('projectKey') : component.projectKey;
+    this.projectKey = defaultTo(params.get('projectKey'), component.projectKey);
     this.state = {
       files: [],
       startDate: null,

--- a/src/main/webapp/linkWizard/LinkWizard.js
+++ b/src/main/webapp/linkWizard/LinkWizard.js
@@ -14,9 +14,12 @@ const LAST_STEP = 1;
 const LinkWizard = hh( class LinkWizard extends Component {
   state = {};
   _isMount = false;
+  projectKey = '';
 
   constructor(props) {
     super(props);
+    const params = new URLSearchParams(this.props.location.search);
+    this.projectKey = params.get('projectKey') != null ? params.get('projectKey') : component.projectKey;
     this.state = {
       files: [],
       startDate: null,
@@ -187,13 +190,12 @@ const LinkWizard = hh( class LinkWizard extends Component {
   };
 
   getConsentCollectionData = () => {
-    const params = new URLSearchParams(this.props.location.search);
     let consentCollectionLink = {};
     // consent group info
     consentCollectionLink.consentKey = this.state.consentGroup.key;
     // consent collection link info
     consentCollectionLink.sampleCollectionId = this.state.sampleCollection.value;
-    consentCollectionLink.projectKey = params.get('projectKey') != null ? params.get('projectKey') : component.projectKey;
+    consentCollectionLink.projectKey = this.projectKey;
     consentCollectionLink.requireMta = this.state.linkFormData.requireMta;
     // security
     consentCollectionLink.pii = this.state.securityInfoFormData.pii == "true" ? true : false;
@@ -363,7 +365,8 @@ const LinkWizard = hh( class LinkWizard extends Component {
             updateForm: this.updateGeneralForm,
             consentGroupIsLoading: this.state.consentGroupIsLoading,
             updateDateRange: this.updateDateRange,
-            generalError: this.state.generalError
+            generalError: this.state.generalError,
+            projectKey: this.projectKey
           }),
           LinkQuestions({
             title: "Security/MTA/International Info",

--- a/src/main/webapp/linkWizard/SelectSampleConsent.js
+++ b/src/main/webapp/linkWizard/SelectSampleConsent.js
@@ -29,9 +29,12 @@ export const SelectSampleConsent = hh(class SelectSampleConsent extends Componen
 
   state = {};
   _isMounted = false;
+  projectKey = '';
 
   constructor(props) {
     super(props);
+    const params = new URLSearchParams(this.props.location.search);
+    this.projectKey = params.get('projectKey') != null ? params.get('projectKey') : component.projectKey;
     this.state = {
       showAddDocuments: false,
       documentOptions: [],
@@ -266,7 +269,7 @@ export const SelectSampleConsent = hh(class SelectSampleConsent extends Componen
         }, [
           InputFieldSelect({
             id: "sampleCollection_select",
-            label: "Link Sample Collection to " + component.projectKey,
+            label: "Link Sample Collection to " + this.projectKey,
             isDisabled: false,
             options: this.state.sampleCollectionList,
             onChange: this.handleSampleCollectionChange,

--- a/src/main/webapp/linkWizard/SelectSampleConsent.js
+++ b/src/main/webapp/linkWizard/SelectSampleConsent.js
@@ -29,12 +29,9 @@ export const SelectSampleConsent = hh(class SelectSampleConsent extends Componen
 
   state = {};
   _isMounted = false;
-  projectKey = '';
 
   constructor(props) {
     super(props);
-    const params = new URLSearchParams(this.props.location.search);
-    this.projectKey = params.get('projectKey') != null ? params.get('projectKey') : component.projectKey;
     this.state = {
       showAddDocuments: false,
       documentOptions: [],
@@ -269,7 +266,7 @@ export const SelectSampleConsent = hh(class SelectSampleConsent extends Componen
         }, [
           InputFieldSelect({
             id: "sampleCollection_select",
-            label: "Link Sample Collection to " + this.projectKey,
+            label: "Link Sample Collection to " + this.props.projectKey,
             isDisabled: false,
             options: this.state.sampleCollectionList,
             onChange: this.handleSampleCollectionChange,
@@ -328,7 +325,6 @@ export const SelectSampleConsent = hh(class SelectSampleConsent extends Componen
               show: this.state.showAddDocuments,
               options: this.state.documentOptions,
               attachDocumentsUrl: this.props.attachDocumentsUrl,
-              projectKey: this.props.projectKey,
               user: this.props.user,
               handleLoadDocuments: this.props.handleLoadDocuments,
               serverURL: this.props.serverURL,

--- a/src/main/webapp/main/Main.js
+++ b/src/main/webapp/main/Main.js
@@ -4,6 +4,7 @@ import { StatusBox } from "../components/StatusBox";
 import { ProjectContainer } from "../projectContainer/ProjectContainer";
 import { ConsentGroupContainer } from "../consentGroupContainer/ConsentGroupContainer";
 import get from 'lodash/get';
+import defaultTo from 'lodash/defaultTo';
 import { isEmpty, projectStatus } from '../util/Utils';
 import './Main.css';
 
@@ -26,9 +27,10 @@ class Main extends Component {
         projectReviewApproved: '',
         attachmentsApproved: ''
       },
-      consentKey: params.get('consentKey') != null ? params.get('consentKey') : component.projectKey,
-      projectKey: params.get('projectKey') != null ? params.get('projectKey') : component.projectKey,
-      tab:  params.get('tab') != null ? params.get('tab') : component.tab,
+
+      consentKey: defaultTo(params.get('consentKey'), component.projectKey),
+      projectKey: defaultTo(params.get('projectKey'), component.projectKey),
+      tab: defaultTo(params.get('tab'), component.tab),
       issueType:  params.get('consentKey') != null ? 'consent-group' : 'project'
     };
   }

--- a/src/main/webapp/main/Main.js
+++ b/src/main/webapp/main/Main.js
@@ -15,6 +15,7 @@ class Main extends Component {
 
   constructor(props) {
     super(props);
+    const params = new URLSearchParams(this.props.location.search);
     this.state = {
       status: {
         type: '',
@@ -25,10 +26,10 @@ class Main extends Component {
         projectReviewApproved: '',
         attachmentsApproved: ''
       },
-      consentKey: this.props.location.state !== undefined && this.props.location.state.consentKey !== undefined  ? this.props.location.state.consentKey : component.consentKey,
-      projectKey: this.props.location.state !== undefined && this.props.location.state.projectKey !== undefined  ? this.props.location.state.projectKey : component.projectKey,
-      tab: this.props.location.state !== undefined && this.props.location.state.tab !== undefined  ? this.props.location.state.tab : component.tab,
-      issueType: this.props.location.state !== undefined && this.props.location.state.issueType !== undefined  ? this.props.location.state.issueType : component.issueType
+      consentKey: params.get('consentKey') != null ? params.get('consentKey') : component.projectKey,
+      projectKey: params.get('projectKey') != null ? params.get('projectKey') : component.projectKey,
+      tab:  params.get('tab') != null ? params.get('tab') : component.tab,
+      issueType:  params.get('consentKey') != null ? 'consent-group' : 'project'
     };
   }
 

--- a/src/main/webapp/main/Routes.js
+++ b/src/main/webapp/main/Routes.js
@@ -45,5 +45,5 @@ const Routes = ( props ) => (
     <Route path= {"/*"} render = {(routeProps) =>  <PageNotFound {...routeProps} {...props}/> }/>
   </Switch>
 );
-
+// /project/main?projectKey=DEV-NE-4333&tab=consent-groups&new
 export default Routes;

--- a/src/main/webapp/main/Routes.js
+++ b/src/main/webapp/main/Routes.js
@@ -45,5 +45,5 @@ const Routes = ( props ) => (
     <Route path= {"/*"} render = {(routeProps) =>  <PageNotFound {...routeProps} {...props}/> }/>
   </Switch>
 );
-// /project/main?projectKey=DEV-NE-4333&tab=consent-groups&new
+
 export default Routes;


### PR DESCRIPTION
## Addresses
[BTRX-798](https://broadinstitute.atlassian.net/browse/BTRX-798): ORSP: Sample/Data Cohort Error
[BTRX-797](https://broadinstitute.atlassian.net/browse/BTRX-797): ORSP: Add existing SDC not working as expected 

## Changes
- Component.projectKey was empty on New Sample Data Cohorts and Add existing components. It was replaced by taking it from the url.
- Redirections through Main component were failing.

## Testing
- Create a new consent group, or Add an existing one. 

---

- [x] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Get a thumb from Belatrix
- [ ] **Submitter**: Get a thumb from @rushtong
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
