### PR TITLE
Landing page columns width - Group as text in ConsentGroup

### DIFF
--- a/src/main/webapp/components/Table.js
+++ b/src/main/webapp/components/Table.js
@@ -18,7 +18,7 @@ const styles = {
   creatorWidth: '130',
   infoLinkWidth: '96',
   creationDateWidth: '140',
-  removeWidth: '45',
+  removeWidth: '50',
   removeWidthFile: '80',
   unlinkSampleCollectionWidth: '80',
   collectionNameWidth: '270',

--- a/src/main/webapp/consentGroupReview/ConsentGroupReview.js
+++ b/src/main/webapp/consentGroupReview/ConsentGroupReview.js
@@ -752,7 +752,7 @@ const ConsentGroupReview = hh(class ConsentGroupReview extends Component {
     const instSources = this.state.formData.instSources === undefined ? [{ current: { name: '', country: '' }, future: { name: '', country: '' } }] : this.state.formData.instSources;
     return (
       div({}, [
-        h2({ className: "stepTitle" }, [" Group as Sample/Data Cohort: " + this.props.consentKey]),
+        h2({ className: "stepTitle" }, [" Sample/Data Cohort: " + this.props.consentKey]),
         button({
           className: "btn buttonPrimary floatRight",
           style: { 'marginTop': '15px' },
@@ -800,7 +800,7 @@ const ConsentGroupReview = hh(class ConsentGroupReview extends Component {
           show: this.state.approveInfoDialog,
           handleOkAction: this.approveConsentGroup,
           title: 'Approve Project Information',
-          bodyText: 'Are you sure you want to approve this  Group as Sample/Data Cohort Details?',
+          bodyText: 'Are you sure you want to approve this Sample/Data Cohort Details?',
           actionLabel: 'Yes'
         }, []),
         ConfirmationDialog({
@@ -808,7 +808,7 @@ const ConsentGroupReview = hh(class ConsentGroupReview extends Component {
           show: this.state.dialog,
           handleOkAction: this.rejectConsentGroup,
           title: 'Remove Confirmation',
-          bodyText: 'Are you sure you want to remove this  Group as Sample/Data Cohort?',
+          bodyText: 'Are you sure you want to remove this Sample/Data Cohort?',
           actionLabel: 'Yes'
         }, []),
         Panel({ title: "Notes to ORSP",
@@ -845,18 +845,18 @@ const ConsentGroupReview = hh(class ConsentGroupReview extends Component {
             errorMessage: "Required field"
           })
         ]),
-        Panel({ title: " Group as Sample/Data Cohort Details" }, [
+        Panel({ title: " Sample/Data Cohort Details" }, [
           InputFieldText({
             id: "inputConsentGroupName",
             name: "consentGroupName",
-            label: " Group as Sample/Data Cohort Name",
+            label: " Sample/Data Cohort Name",
             disabled: !this.state.readOnly,
             value: consent + " / " + protocol,
             currentValue: this.state.current.consentForm.summary,
             onChange: this.handleExtraPropsInputChange,
             readOnly: this.state.readOnly,
             error: this.state.errors.consentGroupName,
-            errorMessage: "An existing  Group as Sample/Data Cohort with this protocol exists. Please choose a different one."
+            errorMessage: "An existing Sample/Data Cohort with this protocol exists. Please choose a different one."
           }),
           InputFieldText({
             id: "inputInvestigatorLastName",

--- a/src/main/webapp/main/LandingPage.js
+++ b/src/main/webapp/main/LandingPage.js
@@ -8,6 +8,14 @@ import { Link } from 'react-router-dom';
 import LoadingWrapper from '../components/LoadingWrapper';
 import { projectStatus } from '../util/Utils';
 
+const styles = {
+  projectWidth: '120px',
+  expirationWidth: '120px',
+  updatedWidth: '130px',
+  typeWidth: '170px',
+  statusWidth: '220px'
+}
+
 const columnsCopy = [{
   dataField: 'project',
   text: 'Project',
@@ -16,6 +24,9 @@ const columnsCopy = [{
     return div({}, [
       linkFormatter(row, row.project)
     ])
+  },
+  headerStyle: (column, colIndex) => {
+    return { width: styles.projectWidth };
   }
 }, {
   dataField: 'title',
@@ -29,19 +40,31 @@ const columnsCopy = [{
 }, {
   dataField: 'status',
   text: 'Status',
-  sort: true
+  sort: true,
+  headerStyle: (column, colIndex) => {
+    return { width: styles.statusWidth };
+  }
 }, {
   dataField: 'type',
   text: 'Type',
-  sort: true
+  sort: true,
+  headerStyle: (column, colIndex) => {
+    return { width: styles.typeWidth };
+  }
 }, {
   dataField: 'updated',
   text: 'Updated',
-  sort: true
+  sort: true,
+  headerStyle: (column, colIndex) => {
+    return { width: styles.updatedWidth };
+  }
 }, {
   dataField: 'expiration',
   text: 'Expiration',
-  sort: true
+  sort: true,
+  headerStyle: (column, colIndex) => {
+    return { width: styles.expirationWidth };
+  }
 }];
 
 const defaultSorted = [{

--- a/src/main/webapp/main/LandingPage.js
+++ b/src/main/webapp/main/LandingPage.js
@@ -20,13 +20,11 @@ const columnsCopy = [{
   dataField: 'project',
   text: 'Project',
   sort: true,
+  headerStyle: { width: styles.projectWidth },
   formatter: (cell, row, rowIndex, colIndex) => {
     return div({}, [
       linkFormatter(row, row.project)
     ])
-  },
-  headerStyle: (column, colIndex) => {
-    return { width: styles.projectWidth };
   }
 }, {
   dataField: 'title',
@@ -41,30 +39,22 @@ const columnsCopy = [{
   dataField: 'status',
   text: 'Status',
   sort: true,
-  headerStyle: (column, colIndex) => {
-    return { width: styles.statusWidth };
-  }
+  headerStyle: { width: styles.statusWidth }
 }, {
   dataField: 'type',
   text: 'Type',
   sort: true,
-  headerStyle: (column, colIndex) => {
-    return { width: styles.typeWidth };
-  }
+  headerStyle: { width: styles.typeWidth }
 }, {
   dataField: 'updated',
   text: 'Updated',
   sort: true,
-  headerStyle: (column, colIndex) => {
-    return { width: styles.updatedWidth };
-  }
+  headerStyle: { width: styles.updatedWidth }
 }, {
   dataField: 'expiration',
   text: 'Expiration',
   sort: true,
-  headerStyle: (column, colIndex) => {
-    return { width: styles.expirationWidth };
-  }
+  headerStyle: { width: styles.expirationWidth }
 }];
 
 const defaultSorted = [{


### PR DESCRIPTION

## Changes
- Landing Page columns adjustment to prioritize "Title" column
- "Group as" text removed from ConsentGroup page

---

- [x] **Submitter**: Verify all tests go green, including CI tests
- [x] **Submitter**: Get a thumb from Belatrix
- [x] **Submitter**: Get a thumb from @rushtong
- [x] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [x] **Submitter**: Delete branch after merge
