### PR TITLE
Data User Restriction Navigation [BTRX-810]

### DIFF
--- a/src/main/webapp/components/Documents.js
+++ b/src/main/webapp/components/Documents.js
@@ -180,7 +180,7 @@ export const Documents = hh(class Documents extends Component {
                 }, ["Create Restriction"]),
                 h(Link, {
                   isRendered: this.props.restrictionId !== null && !component.isViewer, className: "btn buttonPrimary floatLeft",
-                  to: { pathname: UrlConstants.restrictionUrl, search: '?restrictionId=' + this.props.restrictionId + '&consentKey=' + this.props.projectKey }, style: styles.buttonWithLink
+                  to: { pathname: UrlConstants.restrictionUrl, search: '?restrictionId=' + this.props.restrictionId + '&consentKey=' + this.props.projectKey, state: { fromConsentGroup: true }}, style: styles.buttonWithLink
                 }, ["Edit Restriction"]),
                 h(Link, {
                   isRendered: this.props.restrictionId !== null, className: "btn buttonPrimary floatLeft",

--- a/src/main/webapp/consentGroupContainer/ConsentGroupContainer.js
+++ b/src/main/webapp/consentGroupContainer/ConsentGroupContainer.js
@@ -7,6 +7,7 @@ import '../components/Wizard.css';
 import ConsentGroupDocuments from '../consentGroupDocuments/ConsentGroupDocuments';
 import MultiTab from '../components/MultiTab';
 import { ProjectMigration, Review } from '../util/ajax';
+import { isEmpty } from '../util/Utils';
 
 export const ConsentGroupContainer = hh(class ConsentGroupContainer extends Component {
 
@@ -26,6 +27,12 @@ export const ConsentGroupContainer = hh(class ConsentGroupContainer extends Comp
 
   componentDidMount() {
     this._isMounted = true;
+    if (!isEmpty(this.props.tab)) {
+      this.setState(prev => {
+        prev.activeTab = this.props.tab;
+        return prev;
+      })
+    }
     this.getHistory();
     this.getComments();
   }

--- a/src/main/webapp/consentGroupContainer/ConsentGroupContainer.js
+++ b/src/main/webapp/consentGroupContainer/ConsentGroupContainer.js
@@ -8,6 +8,7 @@ import ConsentGroupDocuments from '../consentGroupDocuments/ConsentGroupDocument
 import MultiTab from '../components/MultiTab';
 import { ProjectMigration, Review } from '../util/ajax';
 import { isEmpty } from '../util/Utils';
+import { scrollToTop } from "../util/Utils";
 
 export const ConsentGroupContainer = hh(class ConsentGroupContainer extends Component {
 
@@ -27,6 +28,7 @@ export const ConsentGroupContainer = hh(class ConsentGroupContainer extends Comp
 
   componentDidMount() {
     this._isMounted = true;
+    scrollToTop();
     if (!isEmpty(this.props.tab)) {
       this.setState(prev => {
         prev.activeTab = this.props.tab;

--- a/src/main/webapp/dataUse/DataUseRestrictionEdit.js
+++ b/src/main/webapp/dataUse/DataUseRestrictionEdit.js
@@ -147,11 +147,14 @@ const DataUseRestrictionEdit = hh(class DataUseRestrictionEdit extends Component
       restriction.diseaseRestrictions = this.getKeys(this.state.restriction.diseaseRestrictions)
       restriction.populationRestrictions = this.getKeys(this.state.restriction.populationRestrictions)
       DataUse.createRestriction(restriction).then(resp => {
-        this.props.history.push({
-          pathname: '/newConsentGroup/main',
-          search: '?consentKey=' + this.state.consentKey,
-          state: { issueType: 'consent-group', tab: 'documents', consentKey: this.state.consentKey }
-        })
+        const fromConsentGroup = this.props.location.state != null ? this.props.location.state.fromConsentGroup : false;
+        if (fromConsentGroup) {
+          this.props.history.push({
+            pathname: '/newConsentGroup/main',
+            search: '?consentKey=' + this.state.consentKey + '&tab=documents'});
+        } else {
+          this.props.history.goBack();
+        }        
       }).catch(error => {
         this.setState(() => { throw error; });
       });


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/BTRX-810

## Changes
Navigation after editing a DUR should take the user back to the page where they where.
Those are two different pages:
1. Sample/Data Cohort Document Tab, Data Use Restrictions section, Edit Restriction button.
2. Data Use Restriction View Page, Edit button.

## Testing
Edit a DUR and test redirection

- Note: This is a PR made by Veronica, she is having issues with her GitHub account.
---

- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Get a thumb from Belatrix
- [ ] **Submitter**: Get a thumb from @rushtong
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
