### PR TITLE
BTRX - 830 - Projects API is sending the incorrect status

### DIFF
--- a/grails-app/services/org/broadinstitute/orsp/webservice/ApiService.groovy
+++ b/grails-app/services/org/broadinstitute/orsp/webservice/ApiService.groovy
@@ -54,7 +54,7 @@ class ApiService {
                     "key": it.projectKey,
                     "label": it.projectKey + " (" + it.summary + ")",
                     "type": it.type,
-                    "status": it.status,
+                    "status": it.getApprovalStatus(),
                     "description": it.description,
                     "url": link
             ]


### PR DESCRIPTION
## Addresses
[BTRX-830](https://broadinstitute.atlassian.net/browse/BTRX-830):  Projects API is sending the incorrect status

## Changes
- Since an issue object posses two statuses, it was needed a logic to get old status if the new one is 'Legacy', or get the new otherwise. This logic was already done in Issue's model getter named `getApprovalStatus`. So the fix is done using this getter in the Json that the api builds for this endpoint.

## Testing
- Using a Rest Client hit the endpoint -> <Path>/api/projects
- The value for status, should always match with orsp application. 

---

- [x] **Submitter**: Verify all tests go green, including CI tests
- [x] **Submitter**: Get a thumb from Belatrix
- [x] **Submitter**: Get a thumb from @rushtong
- [x] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [x] **Submitter**: Delete branch after merge
