### PR TITLE
BTRX-836 ORSP: Consent Links should not show deleted Projects or Cohorts

### DIFF
--- a/grails-app/controllers/org/broadinstitute/orsp/api/ReportController.groovy
+++ b/grails-app/controllers/org/broadinstitute/orsp/api/ReportController.groovy
@@ -71,13 +71,16 @@ class ReportController extends AuthenticatedController {
         List<ConsentCollectionLink> links = queryService.findCollectionLinks()
         def result = []
         Collection<DataUseRestriction> durs = queryService.findDataUseRestrictionByConsentGroupKeyInList(links.collect {it.consentKey})
+        List<Issue> consentGroup = queryService.findAllByProjectKeyInList(links.collect {it.consentKey}, null)
         links.groupBy { it.consentKey }.each { key, scLinks ->
             DataUseRestriction restriction = durs.find { it?.consentGroupKey == key }
             result.add([consentGroupKey: key,
                         collections    : scLinks,
-                        restriction    : restriction
+                        restriction    : restriction,
+                        deleted        : consentGroup.find{ it.projectKey == key } == null
             ])
         }
+
         JSON.use(UtilityClass.CONSENT_COLLECTION) {
             render result as JSON
         }

--- a/grails-app/services/org/broadinstitute/orsp/QueryService.groovy
+++ b/grails-app/services/org/broadinstitute/orsp/QueryService.groovy
@@ -1602,7 +1602,7 @@ class QueryService implements Status {
     }
 
     List<ConsentCollectionLink> findCollectionLinks() {
-        String query = 'select ccl.* from consent_collection_link ccl inner join issue i on i.project_key = ccl.consent_key where ccl.deleted = 0 and i.deleted = 0'
+        String query = 'select * from consent_collection_link where deleted = 0 '
         SQLQuery sqlQuery = getSessionFactory().currentSession.createSQLQuery(query)
         List<ConsentCollectionLink> links = sqlQuery.with {
             addEntity(ConsentCollectionLink)
@@ -1621,9 +1621,13 @@ class QueryService implements Status {
 
     PaginatedResponse findAllCollectionLinks(PaginationParams pagination) {
         // get total rows
-        String totalRowsQuery = 'select count(ccl.id) from consent_collection_link ccl ' +
-                ' left join issue project on project.project_key = ccl.project_key left join issue c on c.project_key = ccl.consent_key ' +
-                ' where ccl.deleted = 0 and project.deleted = 0 and c.deleted = 0 ' + getCollectionLinksWhereClause(pagination)
+        String totalRowsQuery =
+                ' select count(ccl.id) from consent_collection_link ccl ' +
+                ' left join issue project on project.project_key = ccl.project_key ' +
+                ' left join issue c on c.project_key = ccl.consent_key ' +
+                ' where ccl.deleted = 0 ' +
+                ' and project.deleted = 0 ' +
+                ' and c.deleted = 0 ' + getCollectionLinksWhereClause(pagination)
         SQLQuery query = getSessionFactory().currentSession.createSQLQuery(totalRowsQuery)
         if (pagination.searchValue) query.setString('term', pagination.getLikeTerm())
         Long totalRows = query.uniqueResult()

--- a/grails-app/services/org/broadinstitute/orsp/QueryService.groovy
+++ b/grails-app/services/org/broadinstitute/orsp/QueryService.groovy
@@ -712,7 +712,7 @@ class QueryService implements Status {
      */
     List<Issue> findAllByProjectKeyInList(List<String> projectKeys, Integer max) {
         if (CollectionUtils.isEmpty(projectKeys)) { return  Collections.emptyList() }
-        String query = 'select * from issue where project_key IN (:projectKeys) order by update_date desc '
+        String query = 'select * from issue where project_key IN (:projectKeys) and deleted = 0 order by update_date desc '
         if (max) { query = query + ' limit ' + max }
         SQLQuery sqlQuery = getSessionFactory().currentSession.createSQLQuery(query)
         List<Issue> issues = sqlQuery.with {
@@ -1114,12 +1114,12 @@ class QueryService implements Status {
         query.append(' where i.type = :type ' +
                 ' and i.deleted = 0 ')
         if (pagination.searchValue) {
-            query.append("and i.project_key LIKE :term ")
+            query.append("and (i.project_key LIKE :term ")
                     .append("or i.summary LIKE :term ")
                     .append("or i.status LIKE :term ")
                     .append("or ((ie.name = :initialReviewType ")
                     .append("or ie.name = :reviewCategory ) ")
-                    .append("and ie.value LIKE :term ) ")
+                    .append("and ie.value LIKE :term ))")
         }
         SQLQuery sqlQuery = session.createSQLQuery(query.toString())
         sqlQuery.setString('type', type)
@@ -1565,14 +1565,14 @@ class QueryService implements Status {
 
     PaginatedResponse findDataUseRestrictions(PaginationParams pagination) {
         // get total rows
-        String query = 'select count(id) from data_use_restriction ' + getDURWhereClause(pagination)
+        String query = 'select count(du.id) from data_use_restriction du inner join issue i on i.project_key = du.consent_group_key ' + getDURWhereClause(pagination)
         String orderColumn = getRestrictionOrderColumn(pagination.orderColumn)
         SQLQuery sqlQuery = getSessionFactory().currentSession.createSQLQuery(query)
         if (pagination.searchValue) sqlQuery.setString('term', pagination.getLikeTerm())
         Long totalRows = sqlQuery.uniqueResult()
 
         // get DUR paginated
-        String durQuery =  'select * from data_use_restriction ' + getDURWhereClause(pagination) + " order by " + orderColumn + pagination.sortDirection
+        String durQuery =  'select * from data_use_restriction du inner join issue i on i.project_key = du.consent_group_key ' + getDURWhereClause(pagination) + " order by " + orderColumn + pagination.sortDirection
         SQLQuery sqlDURQuery = getSessionFactory().currentSession.createSQLQuery(durQuery)
 
         List<DataUseRestriction> results = sqlDURQuery.with {
@@ -1592,15 +1592,17 @@ class QueryService implements Status {
     }
 
     private String getDURWhereClause(PaginationParams pagination) {
-        String where = ''
+        String where
         if (pagination.searchValue) {
-            where = ' where consent_group_key LIKE :term OR vault_export_date LIKE :term '
+            where = ' where (du.consent_group_key LIKE :term OR du.vault_export_date LIKE :term) and i.deleted = 0 '
+        } else {
+            where = ' where i.deleted = 0 '
         }
         where
     }
 
     List<ConsentCollectionLink> findCollectionLinks() {
-        String query = 'select * from consent_collection_link where deleted = 0 '
+        String query = 'select ccl.* from consent_collection_link ccl inner join issue i on i.project_key = ccl.consent_key where ccl.deleted = 0 and i.deleted = 0'
         SQLQuery sqlQuery = getSessionFactory().currentSession.createSQLQuery(query)
         List<ConsentCollectionLink> links = sqlQuery.with {
             addEntity(ConsentCollectionLink)
@@ -1619,12 +1621,16 @@ class QueryService implements Status {
 
     PaginatedResponse findAllCollectionLinks(PaginationParams pagination) {
         // get total rows
-        String totalRowsQuery = 'select count(*) from consent_collection_link where deleted = 0 ' + getCollectionLinksWhereClause(pagination)
+        String totalRowsQuery = 'select count(ccl.id) from consent_collection_link ccl ' +
+                ' left join issue project on project.project_key = ccl.project_key left join issue c on c.project_key = ccl.consent_key ' +
+                ' where ccl.deleted = 0 and project.deleted = 0 and c.deleted = 0 ' + getCollectionLinksWhereClause(pagination)
         SQLQuery query = getSessionFactory().currentSession.createSQLQuery(totalRowsQuery)
         if (pagination.searchValue) query.setString('term', pagination.getLikeTerm())
         Long totalRows = query.uniqueResult()
 
-        String queryCCL = 'select * from consent_collection_link where deleted = 0 ' + getCollectionLinksWhereClause(pagination)
+        String queryCCL = 'select ccl.* from consent_collection_link ccl ' +
+                ' left join issue project on project.project_key = ccl.project_key left join issue c on c.project_key = ccl.consent_key ' +
+                ' where ccl.deleted = 0 and project.deleted = 0 and c.deleted = 0 ' + getCollectionLinksWhereClause(pagination)
         String orderColumn = getSampleCollectionOrderColumn(pagination.orderColumn)
         queryCCL = queryCCL + ' order by ' + orderColumn + pagination.sortDirection
         SQLQuery sqlQuery = getSessionFactory().currentSession.createSQLQuery(queryCCL)
@@ -1645,7 +1651,7 @@ class QueryService implements Status {
     }
 
     List<DataUseRestriction> findDataUseRestrictionByConsentGroupKeyInList(List<String> consentGroupKeys) {
-        String query = 'select * from data_use_restriction where consent_group_key IN :consentGroupKeys '
+        String query = 'select du.* from data_use_restriction du inner join issue i on i.project_key = du.consent_group_key where consent_group_key IN :consentGroupKeys and i.deleted = 0'
         SQLQuery sqlQuery = getSessionFactory().currentSession.createSQLQuery(query)
         sqlQuery.with {
             addEntity(DataUseRestriction)
@@ -1702,7 +1708,7 @@ class QueryService implements Status {
     private String getCollectionLinksWhereClause(pagination) {
         String query = ''
         if (pagination.searchValue) {
-            query = ' and (consent_key LIKE :term OR project_key LIKE :term OR status LIKE :term OR sample_collection_id LIKE :term )'
+            query = ' and (ccl.consent_key LIKE :term OR ccl.project_key LIKE :term OR ccl.status LIKE :term OR ccl.sample_collection_id LIKE :term )'
         }
         query
     }

--- a/src/main/webapp/dataUse/SampleCollectionLinks.js
+++ b/src/main/webapp/dataUse/SampleCollectionLinks.js
@@ -22,9 +22,7 @@ const columns = [
       return { width:  styles.consentCollection.consentKeyWidth};
     },
     formatter: (cell, row, rowIndex, colIndex) =>
-      div({}, [
-        h(Link, {to: {pathname:'/newConsentGroup/main', search: '?consentKey=' + row.consentGroupKey, state: {issueType: 'consent-group', tab: 'documents', consentKey: row.consentGroupKey}}}, [row.consentGroupKey])
-      ])
+      div({}, [ getConsentKey(row) ])
   },
   {
     dataField: 'id',
@@ -49,6 +47,13 @@ const columns = [
   }
 ];
 
+function getConsentKey(row) {
+  let consentKey = row.consentGroupKey;
+  if (!row.deleted) {
+    consentKey = h(Link, {to: {pathname:'/newConsentGroup/main', search: '?consentKey=' + row.consentGroupKey, state: {issueType: 'consent-group', tab: 'documents', consentKey: row.consentGroupKey}}}, [row.consentGroupKey])
+  } 
+  return consentKey;
+}
 function getValue(row) {
   let lis = [];
   row.collections.map(collection => {

--- a/src/main/webapp/util/ReportConstants.js
+++ b/src/main/webapp/util/ReportConstants.js
@@ -53,7 +53,7 @@ export const styles = {
   },
   consentCollection: { 
     consentKeyWidth: '140px',
-    collectionsWidth: '750px'
+    collectionsWidth: '650px'
   }
 };
 

--- a/src/main/webapp/util/ReportConstants.js
+++ b/src/main/webapp/util/ReportConstants.js
@@ -53,7 +53,7 @@ export const styles = {
   },
   consentCollection: { 
     consentKeyWidth: '140px',
-    collectionsWidth: '650px'
+    collectionsWidth: '750px'
   }
 };
 


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/BTRX-836
## Changes
Filter queries by deleted rows
## Testing
1) Go to project, sample data cohort tab, add a new sample data cohort. Reject it. Cohort must not be listed.
2) Go to data use restriction report, rejected Consent Groups must not been shown
3) Go to Review Category Report, rejected projects and consent groups must not been shown
4) Go to Quality Assurance Report, rejected projects must not be shown
5) Go to Consent Collection Links Report, rejected projects and consent groups must not been shown
---

- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Get a thumb from Belatrix
- [ ] **Submitter**: Get a thumb from @rushtong
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
