### PR TITLE
BTRX-833 ORSP: Disable MTA notification

### DIFF
--- a/grails-app/services/org/broadinstitute/orsp/NotifyService.groovy
+++ b/grails-app/services/org/broadinstitute/orsp/NotifyService.groovy
@@ -552,25 +552,6 @@ class NotifyService implements SendgridSupport, Status {
         result
     }
 
-    Map<Boolean, String> sendRequirementsInfoConsentGroup(Issue issue, User user, ConsentCollectionLink consentCollectionLink) {
-        Map<Boolean, String> result = new HashMap<>()
-
-        if (Boolean.valueOf(consentCollectionLink.requireMta)) {
-            NotifyArguments arguments =
-                    new NotifyArguments(
-                            toAddresses: Collections.singletonList(getAgreementsRecipient()),
-                            fromAddress: getDefaultFromAddress(),
-                            ccAddresses: Collections.singletonList(user.getEmailAddress()),
-                            subject: issue.projectKey + " - Required OSAP Follow-up",
-                            user: user,
-                            issue: issue)
-            arguments.view = "/notify/requirements"
-            Mail mail = populateMailFromArguments(arguments)
-            result = sendMail(mail, getApiKey(), getSendGridUrl())
-        }
-        result
-    }
-
     /**
      * Send message to admins when project or consent group is created
      *
@@ -715,7 +696,6 @@ class NotifyService implements SendgridSupport, Status {
     Map<Boolean, String> consentGroupCreation(Issue issue, ConsentCollectionLink consentCollectionLink) {
         User user = userService.findUser(issue.reporter)
         sendAdminNotification(IssueType.CONSENT_GROUP.name, issue)
-        sendRequirementsInfoConsentGroup(issue, user, consentCollectionLink)
         sendSecurityInfo(issue, user, consentCollectionLink)
     }
 

--- a/src/main/webapp/consentGroup/NewLinkCohortData.js
+++ b/src/main/webapp/consentGroup/NewLinkCohortData.js
@@ -1,5 +1,5 @@
 import { Component, Fragment } from 'react';
-import { hh, span } from 'react-hyperscript-helpers';
+import { hh, span, a, i } from 'react-hyperscript-helpers';
 import { InternationalCohorts } from '../components/InternationalCohorts';
 import { Security } from '../components/Security';
 import { Panel } from '../components/Panel';
@@ -89,7 +89,10 @@ export const NewLinkCohortData = hh(class NewLinkCohortData extends Component {
               error: this.props.errors.requireMta && this.props.generalError,
               errorMessage: "Required field",
               edit: false
-            })
+            }),
+            span({ isRendered: this.props.requireMta === "true" }, [i({}, ["Upon receipt of the MTA from the provider, please visit "]),
+              a({ href: "https://converge.broadinstitute.org", target:"_blank", className: "link" }, ["converge.broadinstitute.org"]), span({}, [i({}, [" to submit your MTA request."])])
+            ])
           ])
         ]))
   }

--- a/src/main/webapp/linkWizard/LinkQuestions.js
+++ b/src/main/webapp/linkWizard/LinkQuestions.js
@@ -1,5 +1,5 @@
 import { Component } from 'react';
-import { hh, h1, span } from 'react-hyperscript-helpers';
+import { hh, h1, span, a, i } from 'react-hyperscript-helpers';
 import { WizardStep } from "../components/WizardStep";
 import { Panel } from "../components/Panel";
 import { InternationalCohorts } from "../components/InternationalCohorts";
@@ -94,7 +94,10 @@ export const LinkQuestions = hh(class LinkQuestions extends Component {
             error: this.props.errors.requireMta && this.props.generalError,
             errorMessage: "Required field",
             edit: false
-          })
+          }),
+          span({isRendered: this.props.requireMta === "true"}, [i({}, ["Upon receipt of the MTA from the provider, please visit "]), 
+              a({href: "converge.broadinstitute.org"},["converge.broadinstitute.org"]), span({}, [i({}, [" to submit your MTA request."])])
+          ])
         ])
       ]))
   }

--- a/src/main/webapp/linkWizard/LinkQuestions.js
+++ b/src/main/webapp/linkWizard/LinkQuestions.js
@@ -95,8 +95,8 @@ export const LinkQuestions = hh(class LinkQuestions extends Component {
             errorMessage: "Required field",
             edit: false
           }),
-          span({isRendered: this.props.requireMta === "true"}, [i({}, ["Upon receipt of the MTA from the provider, please visit "]), 
-              a({href: "converge.broadinstitute.org"},["converge.broadinstitute.org"]), span({}, [i({}, [" to submit your MTA request."])])
+          span({ isRendered: this.props.requireMta === "true" }, [i({}, ["Upon receipt of the MTA from the provider, please visit "]),
+            a({ href: "https://converge.broadinstitute.org", target: "_blank", className: "link" }, ["converge.broadinstitute.org"]), span({}, [i({}, [" to submit your MTA request."])])
           ])
         ])
       ]))


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/BTRX-833

## Changes
Remove notification if MTA is selected. 
## Testing
Go to Project -> Consent Group tab. New Sample/Data Cohort. 
Create a new consent. Check MTA in YES. MTA notification must not be sent. A text should be displayed: "Upon receipt of the MTA from the provider, please visit converge.broadinstitute.org, to submit your MTA request."


---

- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Get a thumb from Belatrix
- [ ] **Submitter**: Get a thumb from @rushtong
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
