### PR TITLE
Add text to "About the ORSP Portal" 

### DIFF
--- a/src/main/webapp/aboutPage/AboutPage.js
+++ b/src/main/webapp/aboutPage/AboutPage.js
@@ -11,7 +11,8 @@ class AboutPage extends Component {
   render() {
     return (
         About({
-            showAccessDetails : true
+            showAccessDetails : true,
+            showWarning: true
         })
     );
   }

--- a/src/main/webapp/components/About.js
+++ b/src/main/webapp/components/About.js
@@ -64,7 +64,7 @@ export const About = hh(class About extends Component {
               href:"mailto:orsp-portal@broadinstitute.org"}, ["orsp-portal@broadinstitute.org"]
             ), " for assistance."
           ]),
-          p({isRendered: this.props.showWarning !== false, style: { fontFamily : styles.fontFamily, fontSize: styles.textFontSize, padding:"15px", border:"1px solid #CCCCCC", borderRadius:"6px", margin:"20px 0 30px 0"  }},[
+          p({ isRendered: this.props.showWarning, style: { fontFamily : styles.fontFamily, fontSize: styles.textFontSize, padding:"15px", border:"1px solid #CCCCCC", borderRadius:"6px", margin:"20px 0 30px 0"}},[
             "Please note that Microsoft Edge and Internet Explorer are not supported browsers for the ORSP Portal. Please use Google Chrome or Firefox instead."
           ]),
           div({ isRendered:  component.isBroad && showAccessDetails}, [

--- a/src/main/webapp/components/About.js
+++ b/src/main/webapp/components/About.js
@@ -64,6 +64,9 @@ export const About = hh(class About extends Component {
               href:"mailto:orsp-portal@broadinstitute.org"}, ["orsp-portal@broadinstitute.org"]
             ), " for assistance."
           ]),
+          p({isRendered: this.props.showWarning !== false, style: { fontFamily : styles.fontFamily, fontSize: styles.textFontSize, padding:"15px", border:"1px solid #CCCCCC", borderRadius:"6px", margin:"20px 0 30px 0"  }},[
+            "Please note that Microsoft Edge and Internet Explorer are not supported browsers for the ORSP Portal. Please use Google Chrome or Firefox instead."
+          ]),
           div({ isRendered:  component.isBroad && showAccessDetails}, [
               h3({ style: { fontSize: styles.titleSize }}, ["User Guide"]),
               p({ style: { fontFamily : styles.fontFamily, fontSize: styles.textFontSize }},[

--- a/src/main/webapp/main/LandingPage.js
+++ b/src/main/webapp/main/LandingPage.js
@@ -161,7 +161,7 @@ const LandingPage = hh(class LandingPage extends Component{
   render() {
      return (
       div({}, [
-        About(),
+        About({showWarning: false}),
         div({className: "row", isRendered: component.isBroad === true}, [
           div({className: "col-xs-12"}, [
             h3({style: {'fontWeight' : 'bold'}}, ["My Task List ",


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/ORSP-2

## Changes
Update About page to include new text
## Testing
Go to about page, the following text should be displayed:
 PLEASE NOTE THAT MICROSOFT EDGE AND INTERNET EXPLORER ARE NOT SUPPORTED BROWSERS FOR THE ORSP PORTAL. PLEASE USE GOOGLE CHROME OR FIREFOX INSTEAD.
---

- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Get a thumb from Belatrix
- [ ] **Submitter**: Get a thumb from @rushtong
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
