### PR TITLE
ORSP-5 Documents added to Cohort should display under Cohort Documents tab

### DIFF
--- a/grails-app/migrations/changelog-master.xml
+++ b/grails-app/migrations/changelog-master.xml
@@ -21,4 +21,5 @@
     <include file="changesets/changelog-17.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-18.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-19.0.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/changelog-20.0.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/grails-app/migrations/changesets/changelog-20.0.xml
+++ b/grails-app/migrations/changesets/changelog-20.0.xml
@@ -1,0 +1,15 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet id="changelog-20" author="vvicario">
+        <sql>
+            UPDATE storage_document AS sd
+            INNER JOIN consent_collection_link AS ccl
+            ON sd.consent_collection_link_id = ccl.id
+            AND sd.project_key is null
+            SET sd.project_key = ccl.consent_key;
+        </sql>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/ORSP-5
https://broadinstitute.atlassian.net/browse/ORSP-12
## Changes
If a document is related to consent collection link its project key was set to null.
This behavior was changed at some point, now documents have project key. If it's related to consent collection link, it must have  a consent key set as project key.
During this transition some documents were not updated to include it, so they have null project key. In order to fix it, we need to update any occurrence where the id is null.
## Testing
It's needed to have some documents related to consent_collection_link with null project_key in storage_document. 
Before run the script:
Go to  the consent group  => documents tab. Documents whose project key is null in storage document will not display.
Run the script:
Go to  the consent group  => documents tab. Documents whose project_key were null in storage_document will display. 
Storage document table shouldn't have documents with null project key as value


- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Get a thumb from Belatrix
- [ ] **Submitter**: Get a thumb from ORSP representative
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
