### PR TITLE
ORSP-14 & ORSP-15 Add GSO to eDUL form for DUOS export [NIH request] - Add Data Use Restriction detail to consent export from eDUL questions

### DIFF
--- a/grails-app/domain/org/broadinstitute/orsp/DataUseRestriction.groovy
+++ b/grails-app/domain/org/broadinstitute/orsp/DataUseRestriction.groovy
@@ -42,6 +42,7 @@ class DataUseRestriction {
     Boolean publicationResults
     Boolean genomicResults
     String genomicSummaryResults
+    Boolean geneticStudiesOnly
 
     static constraints = {
         consentGroupKey nullable: false, unique: true
@@ -79,6 +80,7 @@ class DataUseRestriction {
         vaultExportDate nullable: true
         vaultConsentId nullable: true
         vaultConsentLocation nullable: true
+        geneticStudiesOnly nullable: true
     }
 
     static hasMany = [diseaseRestrictions: String, populationRestrictions: String]

--- a/grails-app/migrations/changelog-master.xml
+++ b/grails-app/migrations/changelog-master.xml
@@ -22,4 +22,5 @@
     <include file="changesets/changelog-18.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-19.0.xml" relativeToChangelogFile="true"/>
     <include file="changesets/changelog-20.0.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/changelog-21.0.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/grails-app/migrations/changesets/changelog-21.0.xml
+++ b/grails-app/migrations/changesets/changelog-21.0.xml
@@ -1,0 +1,11 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="vvicario" id="changelog-21">
+        <addColumn tableName="data_use_restriction">
+            <column name="genetic_studies_only" type="BIT(1)"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/grails-app/services/org/broadinstitute/orsp/ConsentService.groovy
+++ b/grails-app/services/org/broadinstitute/orsp/ConsentService.groovy
@@ -35,6 +35,7 @@ class ConsentService implements Status {
     private static final String YES = "Yes"
     private static final String FEMALE = "Female"
     private static final String MALE = "Male"
+    private static final String GENETIC_STUDIES_ONLY_TERM = "http://purl.obolibrary.org/obo/DUO_0000016"
 
     /**
      * Consent Codes come in three flavors, *_POS, *_NEG, and *_NA for when a DUR question is
@@ -62,6 +63,7 @@ class ConsentService implements Status {
     public static final String DATE_POS = "Data distributor must verify that data from samples collected before %s will not be shared."
     public static final String AGGREGATE_POS = "Aggregate level data for general research use is prohibited."
     public static final String MANUAL_REVIEW = "Data access requests will require manual review."
+    public static final String GENETIC_STUDIES_ONLY = "Future use is limited to genetic studies only [GSO]"
 
     // Terms of use/notes
     public static final String RECONTACT_MAY = "Subject re-contact may occur in certain circumstances, as specified: %s"
@@ -294,6 +296,11 @@ class ConsentService implements Status {
             resource.useRestriction = useRestriction.asJsonObject
         }
         resource.requiresManualReview = dataUseRestriction.manualReview
+        resource.collaborationInvestigators = dataUseRestriction.collaborationInvestigators
+        resource.publicationResults = dataUseRestriction.publicationResults
+        resource.genomicResults = dataUseRestriction.genomicResults
+        resource.genomicSummaryResults = dataUseRestriction.genomicSummaryResults
+        resource.geneticStudiesOnly = dataUseRestriction.geneticStudiesOnly ? GENETIC_STUDIES_ONLY_TERM : null
         resource
     }
 
@@ -444,6 +451,7 @@ class ConsentService implements Status {
         if (dataUseRestriction.geographicalRestrictions && !dataUseRestriction.geographicalRestrictions.isEmpty()) summary.add(sprintf(GEO_RESTRICTION, dataUseRestriction.geographicalRestrictions))
         if (dataUseRestriction.other && !dataUseRestriction.other.isEmpty()) summary.add(sprintf(OTHER_POS, stripTextOfHtml(dataUseRestriction.other)))
         if (dataUseRestriction.manualReview) summary.add(MANUAL_REVIEW)
+        if (dataUseRestriction.geneticStudiesOnly) summary.add(GENETIC_STUDIES_ONLY)
         summary
     }
 

--- a/grails-app/services/org/broadinstitute/orsp/ConsentService.groovy
+++ b/grails-app/services/org/broadinstitute/orsp/ConsentService.groovy
@@ -64,6 +64,8 @@ class ConsentService implements Status {
     public static final String AGGREGATE_POS = "Aggregate level data for general research use is prohibited."
     public static final String MANUAL_REVIEW = "Data access requests will require manual review."
     public static final String GENETIC_STUDIES_ONLY = "Future use is limited to genetic studies only [GSO]"
+    public static final String COLLABORATION_INVESTIGATOR = "Collaboration with the primary study investigators required"
+    public static final String GENOMIC_RESULTS = "Genomic summary results from this study are available only through controlled-access"
 
     // Terms of use/notes
     public static final String RECONTACT_MAY = "Subject re-contact may occur in certain circumstances, as specified: %s"
@@ -452,6 +454,8 @@ class ConsentService implements Status {
         if (dataUseRestriction.other && !dataUseRestriction.other.isEmpty()) summary.add(sprintf(OTHER_POS, stripTextOfHtml(dataUseRestriction.other)))
         if (dataUseRestriction.manualReview) summary.add(MANUAL_REVIEW)
         if (dataUseRestriction.geneticStudiesOnly) summary.add(GENETIC_STUDIES_ONLY)
+        if (dataUseRestriction.collaborationInvestigators) summary.add(COLLABORATION_INVESTIGATOR)
+        if (dataUseRestriction.genomicResults) summary.add(GENOMIC_RESULTS)
         summary
     }
 

--- a/grails-app/utils/org/broadinstitute/orsp/utils/DataUseRestrictionParser.groovy
+++ b/grails-app/utils/org/broadinstitute/orsp/utils/DataUseRestrictionParser.groovy
@@ -66,6 +66,7 @@ class DataUseRestrictionParser {
         dataUseRestriction.collaborationInvestigators = IssueUtils.getBooleanForParam(params.collaborationInvestigators)
         dataUseRestriction.publicationResults = IssueUtils.getBooleanForParam(params.publicationResults)
         dataUseRestriction.genomicResults = IssueUtils.getBooleanForParam(params.genomicResults)
+        dataUseRestriction.geneticStudiesOnly = IssueUtils.getBooleanForParam(params.geneticStudiesOnly)
         if (dataUseRestriction.genomicResults) {
             dataUseRestriction.genomicSummaryResults = (String)params.genomicSummaryResults
         } else {

--- a/src/main/groovy/org/broadinstitute/orsp/consent/ConsentResource.groovy
+++ b/src/main/groovy/org/broadinstitute/orsp/consent/ConsentResource.groovy
@@ -22,6 +22,12 @@ class ConsentResource {
     Timestamp sortDate
     String translatedUseRestriction
     DataUseDTO dataUse
+    String geneticStudiesOnly
+    Boolean publicationResults
+    Boolean genomicResults
+    String genomicSummaryResults
+    Boolean collaborationInvestigators
+
     @Override
     String toString() {
         new GsonBuilder().setPrettyPrinting().create().toJson(this).toString()

--- a/src/main/webapp/dataUse/DataUseRestrictionConstants.js
+++ b/src/main/webapp/dataUse/DataUseRestrictionConstants.js
@@ -65,111 +65,117 @@ export const DUR_QUESTIONS = [
     id: 10
   },
   {
+    question: 'Future use is limited to genetic studies only',
+    boolean: true,
+    fieldName: 'geneticStudiesOnly',
+    id: 11
+  },
+  {
     question: 'Future use is limited to research involving a particular gender',
     boolean: false,
     fieldName: 'gender',
-    id: 11
+    id: 12
   },
   {
     question: 'Future use is limited to pediatric research',
     boolean: true,
     fieldName: 'pediatricLimited',
-    id: 12
+    id: 13
   },
   {
     question: 'Future use is limited to research involving a specific population',
     boolean: false,
     fieldName: 'populationRestrictions',
-    id: 13
+    id: 14
   },
   {
     question: 'Future use is limited to data generated from samples collected after the following consent form date',
     boolean: false,
     fieldName: 'dateRestriction',
-    id: 14
+    id: 15
   },
   {
     question: 'Subject re-contact <strong> may </strong> occur in certain circumstances, as specified ',
     boolean: false,
     fieldName: 'recontactMay',
-    id: 15
+    id: 16
   },
   {
     question: 'Subject re-contact <strong> must </strong> occur in certain circumstances, as specified ',
     boolean: false,
     fieldName: 'recontactMust',
-    id: 16
+    id: 17
   },
   {
     question: 'Participants genomic and phenotypic data is available for future research and broad sharing ',
     boolean: false,
     fieldName: 'genomicPhenotypicData',
-    id: 17
+    id: 18
   },
   {
     question: 'Collaboration with the primary study investigators required',
     boolean: true,
     fieldName: 'collaborationInvestigators',
-    id: 18
+    id: 19
   },
   {
     question: 'Data storage on the cloud is prohibited',
     boolean: false,
     fieldName: 'cloudStorage',
-    id: 19
+    id: 20
   },
   {
     question: 'Ethics committee approval is required',
     boolean: true,
     fieldName: 'irb',
-    id: 20
+    id: 21
   },
   {
     question: 'Publication of results of studies using the data is required ',
     boolean: true,
     fieldName: 'publicationResults',
-    id: 21
+    id: 22
   },
   {
     question: 'Genomic summary results from this study are available only through controlled-access',
     boolean: true,
     fieldName: 'genomicResults',
-    id: 22
+    id: 23
   },
   {
     question: 'Genomic summary',
     boolean: false,
     fieldName: 'genomicSummaryResults',
-    id: 23
+    id: 24
   },
   {
     question: 'Geographical restrictions',
     boolean: false,
     fieldName: 'geographicalRestrictions',
-    id: 24
+    id: 25
   },
   {
     question: 'Other Restrictions',
     boolean: false,
     fieldName: 'other',
-    id: 25
+    id: 26
   },
   {
     question: 'Future use of this data requires manual review',
     boolean: true,
     fieldName: 'manualReview',
-    id: 26
+    id: 27
   },
   {
     question: 'ORSP Comments',
     boolean: false,
     fieldName: 'comments',
-    id: 27
+    id: 28
   },
   {
     question: 'DUOS Export',
     boolean: false,
     fieldName: 'vaultExportDate',
-    id: 28
+    id: 29
   }
 ];

--- a/src/main/webapp/dataUse/DataUseRestrictionDetails.js
+++ b/src/main/webapp/dataUse/DataUseRestrictionDetails.js
@@ -10,7 +10,6 @@ import { Link } from 'react-router-dom';
 import { UrlConstants } from '../util/UrlConstants';
 import LoadingWrapper from '../components/LoadingWrapper';
 
-
 const styles = {
   tableList: {
     padding: '0',
@@ -121,7 +120,7 @@ const DataUseRestrictionDetails = hh(class DataUseRestrictionDetails extends Com
     }
     let style = index % 2 == 0 ? styles.tableListRowOdd : styles.tableListRow;
     return li({ style: style, key: index }, [
-        span({ style: styles.tableListColLeft }, [p({ style: styles.tableListItem }, [columnLeft])]),
+        span({ style: styles.tableListColLeft }, [p({ style: styles.tableListItem, dangerouslySetInnerHTML: { __html: columnLeft }}, [])]),
         span({ style: styles.tableListColRight }, [contentRight])
       ]);
   }
@@ -226,18 +225,18 @@ const DataUseRestrictionDetails = hh(class DataUseRestrictionDetails extends Com
                   return this.createRowList(rd.question, this.state.restriction[rd.fieldName], idx);
                 }
                 // date format
-                else if (idx === 14) {
+                else if (idx === 15) {
                   return this.createRow(rd.question, !isEmpty(this.state.restriction[rd.fieldName]) ? format(new Date(this.state.restriction[rd.fieldName]), 'MM/DD/YYYY') : '', idx);
                 }
-                else if (idx === 15 || idx === 16) {
+                else if (idx === 16 || idx === 17) {
                   if (this.state.restriction['recontactingDataSubjects']) {
                     return this.createRow(rd.question, this.state.restriction[rd.fieldName], idx);
                   }
                 }
-                else if (idx === 23) {
+                else if (idx === 24) {
                   return this.createRow(rd.question, this.state.restriction[rd.fieldName] ? this.state.restriction[rd.fieldName] : "--", idx);
                 }
-                else if(idx === 28) {
+                else if(idx === 29) {
                   return this.createDuosExportRow('DUOS Export', idx);
                 }
                 else {

--- a/src/main/webapp/dataUse/DataUseRestrictionEdit.js
+++ b/src/main/webapp/dataUse/DataUseRestrictionEdit.js
@@ -86,7 +86,8 @@ const DataUseRestrictionEdit = hh(class DataUseRestrictionEdit extends Component
       populationRestrictions: restriction != null ? this.getAutocompleteData(restriction.populationRestrictions) : [],
       genomicSummaryResults: restriction != null && !isEmpty(restriction.genomicSummaryResults) ? restriction.genomicSummaryResults : '',
       genomicPhenotypicData: restriction != null && !isEmpty(restriction.genomicPhenotypicData) ? restriction.genomicPhenotypicData : '',
-      consentPIName: get(restriction, 'consentPIName','')
+      consentPIName: get(restriction, 'consentPIName',''),
+      geneticStudiesOnly: get(restriction, 'geneticStudiesOnly')
     };
     return resp;
   }
@@ -683,6 +684,18 @@ const DataUseRestrictionEdit = hh(class DataUseRestrictionEdit extends Component
             span({ className: "radioCheck" }, []),
             span({ className: "radioLabel" }, ["Unspecified"])
           ])
+        ]),
+        div({ style: styles.borderedContainer, className: "radioContainer" }, [
+          div({ style: styles.inputGroup }, [
+            InputYesNo({
+              id: "radioGeneticStudies",
+              name: "geneticStudiesOnly",
+              value: this.state.restriction.geneticStudiesOnly,
+              label: "Future use is limited to genetic studies only [GSO]",
+              readOnly: false,
+              onChange: this.handleRadioChange
+            })
+          ]),
         ]),
         div({ style: styles.borderedContainer, className: "radioContainer" }, [
           label({ className: "inputFieldLabel" }, ["Future use is limited to research involving a particular gender [RS-M] / [RS-FM]"]),


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/ORSP-15
https://broadinstitute.atlassian.net/browse/ORSP-14
## Changes
1) Add "Future use is limited to genetic studies only [GSO]" question to the Edit Data Use Restrictions page. 
2) Populate with the following information  collaborationInvestigators, publicationResults, genomicResults, genomicSummaryResults, geographicalRestrictions and geneticStudiesOnly to consent export
## Testing
Review attached images
![geneticStudiesQuestion](https://user-images.githubusercontent.com/56607220/71120813-eacb1480-21bb-11ea-9bee-71d519a957ca.png)
![DUR](https://user-images.githubusercontent.com/56607220/71121010-4e554200-21bc-11ea-8bec-6173f026c7e0.png)


---

- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Get a thumb from Belatrix
- [ ] **Submitter**: Get a thumb from ORSP representative
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
