### PR TITLE
Improve performance after removing or  assigning an ORSP admin

### DIFF
--- a/src/main/webapp/components/UserListDialog.js
+++ b/src/main/webapp/components/UserListDialog.js
@@ -51,11 +51,12 @@ const UserListDialog = hh(class UserListDialog extends Component {
       prev.submit = true;
       return prev;
     });
-    const assignedAdmin = this.state.assignedAdmin.key;
-    const data = { assignedAdmin: assignedAdmin};
-    await Project.addExtraProperties(this.props.issueKey, data);
+    const assignedAdmin = this.state.assignedAdmin;
+    const issueKey = this.props.issueKey;
+    const data = { assignedAdmin: assignedAdmin.key };
+    await Project.addExtraProperties(issueKey, data);
     this.handleClose();
-    this.props.success(assignedAdmin);
+    this.props.success(issueKey, assignedAdmin.value);
   }
 
 

--- a/src/main/webapp/components/UserListDialog.js
+++ b/src/main/webapp/components/UserListDialog.js
@@ -51,10 +51,11 @@ const UserListDialog = hh(class UserListDialog extends Component {
       prev.submit = true;
       return prev;
     });
-    const data = { assignedAdmin: this.state.assignedAdmin.key };
+    const assignedAdmin = this.state.assignedAdmin.key;
+    const data = { assignedAdmin: assignedAdmin};
     await Project.addExtraProperties(this.props.issueKey, data);
     this.handleClose();
-    this.props.success();
+    this.props.success(assignedAdmin);
   }
 
 

--- a/src/main/webapp/issueList/IssueList.js
+++ b/src/main/webapp/issueList/IssueList.js
@@ -11,6 +11,7 @@ import '../index.css';
 import LoadingWrapper from '../components/LoadingWrapper';
 import UserListDialog from '../components/UserListDialog';
 import isEmpty from 'lodash/isEmpty';
+import findIndex from 'lodash/findIndex';
 import '../components/Btn.css';
 
 const stylesHeader = {
@@ -137,7 +138,7 @@ const columns = (ref) => [
               id: "assignedBtn",
               className: "btnPrimary",
               style: { backgroundColor: 'transparent' },
-              onClick: () => ref.removeAssignedAdmin(row.projectKey)
+              onClick: () => ref.removeAssignedAdmin(row)
             }, [
               span({ className: "glyphicon glyphicon-remove", style: { color: '#95a5a6' } }, []),
             ])
@@ -271,9 +272,20 @@ const IssueList = hh(class IssueList extends Component {
     });
   };
 
-  removeAssignedAdmin = async (projectKey) => {
-    await Project.removeAssignedAdmin(projectKey);
-    this.init();
+  removeAssignedAdmin = async (row) => {
+    this.props.showSpinner();
+    Project.removeAssignedAdmin(row.projectKey).then(resp => {
+      let issues = this.state.issues;
+      var index = findIndex(issues, { projectKey: row.projectKey });
+      issues[index].assignedAdmin = null;
+      this.setState(prev => {
+        prev.issues = issues;
+        return prev;
+      });
+      this.props.hideSpinner();
+    }).catch(error => {
+      this.handleError(error);
+    });    
   }
 
   success = () => {

--- a/src/main/webapp/issueList/IssueList.js
+++ b/src/main/webapp/issueList/IssueList.js
@@ -275,21 +275,25 @@ const IssueList = hh(class IssueList extends Component {
   removeAssignedAdmin = async (row) => {
     this.props.showSpinner();
     Project.removeAssignedAdmin(row.projectKey).then(resp => {
-      let issues = this.state.issues;
-      var index = findIndex(issues, { projectKey: row.projectKey });
-      issues[index].assignedAdmin = null;
-      this.setState(prev => {
-        prev.issues = issues;
-        return prev;
-      });
+      this.setAdmin(null, row.projectKey);
       this.props.hideSpinner();
     }).catch(error => {
       this.handleError(error);
-    });    
+    });
   }
 
-  success = () => {
-    this.init();
+  success = (issueKey, assignedAdmin) => {
+    this.setAdmin(assignedAdmin, issueKey);
+  }
+
+  setAdmin(assignedAdmin, projectKey) {
+    let issues = this.state.issues;
+    var index = findIndex(issues, { projectKey: projectKey });
+    issues[index].assignedAdmin = assignedAdmin;
+    this.setState(prev => {
+      prev.issues = issues;
+      return prev;
+    });
   }
 
   render() {


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/ORSP-3

## Changes
It's not necessary to do a backend call to get all the information after removing or assigning a new ORSP admin. It increases the time if users have several projects in their list.. 
I removed the init call inside this functionctionallity and I updated the specific project with the new value.
## Testing
Login with an admin user. Go to My Task List and my project list from index page.  Assing admin column should be displayed. You should be able to assing and remove an ORSP Admin
---

- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Get a thumb from Belatrix
- [ ] **Submitter**: Get a thumb from ORSP representative
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
