### PR TITLE
ORSP-17 Set Submission Tab Defaults to order from highest to lowest

### DIFF
--- a/grails-app/services/org/broadinstitute/orsp/QueryService.groovy
+++ b/grails-app/services/org/broadinstitute/orsp/QueryService.groovy
@@ -1179,7 +1179,16 @@ class QueryService implements Status {
 
     Collection<Submission> getSubmissionsByProject(String projectKey) {
         if (!projectKey) return Collections.emptyList()
-        Submission.findAllByProjectKey(projectKey)
+        final session = sessionFactory.currentSession
+        final String query =
+                'select * from submission where project_key = :projectKey ORDER BY number DESC'
+
+        final sqlQuery = session.createSQLQuery(query)
+        sqlQuery.with {
+            setString('projectKey', projectKey)
+            addEntity(Submission)
+            list()
+        }
     }
 
     Collection<Integer> getSubmissionNumber(String projectKey, String  type, String number) {


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/ORSP-17
## Changes
Remove GORM and create a new query to get the information order by number DESC
## Testing
Open a project. Go to Submissions. Each tab (Amendement, Continuing Review, Other Event and Other) should appear from highest to lowest number
---

- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Get a thumb from Belatrix
- [ ] **Submitter**: Get a thumb from ORSP representative
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
