### PR TITLE
ORPS-20 Add "On hold" option to choices that appear on "Admin Only" tab, under "Project Status"

### DIFF
--- a/src/main/groovy/org/broadinstitute/orsp/IssueStatus.groovy
+++ b/src/main/groovy/org/broadinstitute/orsp/IssueStatus.groovy
@@ -26,8 +26,8 @@ enum IssueStatus {
     Legacy(14, "Legacy"),
     Intake(15, "Intake"),
     Reopened(16, "Reopened"),
-    Disapproved(17, "Disapproved")
-
+    Disapproved(17, "Disapproved"),
+    OnHold(18, "On Hold")
 
     Integer sequence
     String name

--- a/src/main/webapp/adminOnly/AdminOnly.js
+++ b/src/main/webapp/adminOnly/AdminOnly.js
@@ -253,13 +253,14 @@ const AdminOnly = hh(class AdminOnly extends Component {
             name: "projectStatus",
             label: "Project Status",
             value: this.state.formData.projectStatus,
-            optionValues: ['Approved', 'Disapproved', 'Withdrawn', 'Closed', 'Abandoned'],
+            optionValues: ['Approved', 'Disapproved', 'Withdrawn', 'Closed', 'Abandoned', 'On Hold'],
             optionLabels: [
               "Approved",
               "Disapproved",
               "Withdrawn",
               "Closed",
-              "Abandoned"
+              "Abandoned",
+              "On Hold"
             ],
             onChange: this.radioBtnHandler,
             readOnly: !this.state.isAdmin

--- a/src/main/webapp/search/Search.js
+++ b/src/main/webapp/search/Search.js
@@ -11,7 +11,7 @@ import { SampleCollections } from "../util/ajax";
 import { isEmpty } from '../util/Utils';
 import "./style.css";
 
-const newStatuses = ["Legacy", "Pending ORSP Admin Review", "Approved", "Disapproved", "Withdrawn", "Closed", "Abandoned", "Disapproved"];
+const newStatuses = ["Legacy", "Pending ORSP Admin Review", "Approved", "Disapproved", "Withdrawn", "Closed", "Abandoned", "On Hold"];
 
 const styles = {
   inputStyle: {


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/ORSP-20

## Changes
Add new status under Project Status, Admin Only Tab

## Testing
Open a project, go to Admin Only tab. On Hold option under Project Status should appear. Select "On Hold" and save. 
Go to search page. Filter by "On Hold" status, the just updated project should be displayed.
---

- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Get a thumb from Belatrix
- [ ] **Submitter**: Get a thumb from ORSP representative
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
