### PR TITLE
ORSP-29 Data Use Restriction - Update data use schema

### DIFF
--- a/grails-app/services/org/broadinstitute/orsp/ConsentService.groovy
+++ b/grails-app/services/org/broadinstitute/orsp/ConsentService.groovy
@@ -137,7 +137,7 @@ class ConsentService implements Status {
     def postDataUseLetter(String consentLocation, InputStream inputStream, String fileName) {
         String url = consentLocation + "/dul"
         HttpBuilder http = getMultipartBuilder(url)
-        String fileType = MediaType.APPLICATION_OCTET_STREAM_VALUE
+        String fileType = MediaType.APPLICATION_OCTET_STREAM_VALUEc
         http.post(Boolean) {
             // "data" is the expected form field name in the consent service
             request.body = multipart {
@@ -298,11 +298,6 @@ class ConsentService implements Status {
             resource.useRestriction = useRestriction.asJsonObject
         }
         resource.requiresManualReview = dataUseRestriction.manualReview
-        resource.collaborationInvestigators = dataUseRestriction.collaborationInvestigators
-        resource.publicationResults = dataUseRestriction.publicationResults
-        resource.genomicResults = dataUseRestriction.genomicResults
-        resource.genomicSummaryResults = dataUseRestriction.genomicSummaryResults
-        resource.geneticStudiesOnly = dataUseRestriction.geneticStudiesOnly ? GENETIC_STUDIES_ONLY_TERM : null
         resource
     }
 
@@ -394,6 +389,26 @@ class ConsentService implements Status {
 
         if (dataUseRestriction.other) {
             dataUseDTO.setOther(stripTextOfHtml(dataUseRestriction.other).trim())
+        }
+
+        if (dataUseRestriction.collaborationInvestigators) {
+            dataUseDTO.collaborationInvestigators = true
+        }
+
+        if (dataUseRestriction.publicationResults) {
+            dataUseDTO.publicationResults = true
+        }
+
+        if (dataUseRestriction.genomicResults) {
+            dataUseDTO.genomicResults = true
+        }
+
+        if (dataUseRestriction.genomicSummaryResults) {
+            dataUseDTO.setGenomicSummaryResults(dataUseRestriction.genomicSummaryResults)
+        }
+
+        if (dataUseRestriction.geneticStudiesOnly) {
+            dataUseDTO.geneticStudiesOnly = true
         }
 
         dataUseDTO

--- a/grails-app/services/org/broadinstitute/orsp/ConsentService.groovy
+++ b/grails-app/services/org/broadinstitute/orsp/ConsentService.groovy
@@ -137,7 +137,7 @@ class ConsentService implements Status {
     def postDataUseLetter(String consentLocation, InputStream inputStream, String fileName) {
         String url = consentLocation + "/dul"
         HttpBuilder http = getMultipartBuilder(url)
-        String fileType = MediaType.APPLICATION_OCTET_STREAM_VALUEc
+        String fileType = MediaType.APPLICATION_OCTET_STREAM_VALUE
         http.post(Boolean) {
             // "data" is the expected form field name in the consent service
             request.body = multipart {

--- a/src/main/groovy/org/broadinstitute/orsp/consent/ConsentResource.groovy
+++ b/src/main/groovy/org/broadinstitute/orsp/consent/ConsentResource.groovy
@@ -22,11 +22,6 @@ class ConsentResource {
     Timestamp sortDate
     String translatedUseRestriction
     DataUseDTO dataUse
-    Boolean geneticStudiesOnly
-    Boolean publicationResults
-    Boolean genomicResults
-    String genomicSummaryResults
-    Boolean collaborationInvestigators
 
     @Override
     String toString() {

--- a/src/main/groovy/org/broadinstitute/orsp/consent/ConsentResource.groovy
+++ b/src/main/groovy/org/broadinstitute/orsp/consent/ConsentResource.groovy
@@ -22,7 +22,7 @@ class ConsentResource {
     Timestamp sortDate
     String translatedUseRestriction
     DataUseDTO dataUse
-    String geneticStudiesOnly
+    Boolean geneticStudiesOnly
     Boolean publicationResults
     Boolean genomicResults
     String genomicSummaryResults

--- a/src/main/groovy/org/broadinstitute/orsp/consent/DataUseDTO.groovy
+++ b/src/main/groovy/org/broadinstitute/orsp/consent/DataUseDTO.groovy
@@ -32,4 +32,9 @@ class DataUseDTO {
     Boolean vulnerablePopulations
     Boolean psychologicalTraits
     Boolean nonBiomedical
+    Boolean geneticStudiesOnly
+    Boolean publicationResults
+    Boolean genomicResults
+    String genomicSummaryResults
+    Boolean collaborationInvestigators
 }


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/ORSP-29

## Changes
Move new terms from ConsentResource to DataUseDTO

## Testing
Describe for the reviewer how to test the specifics of this PR, both positive and negative cases.

---

- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Get a thumb from Belatrix
- [ ] **Submitter**: Get a thumb from ORSP representative
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
