### PR TITLE
Orsp 30 Allow multiple Project Manager on the Project Details page to display all Project Managers associated with a project

### DIFF
--- a/src/main/webapp/project/NewProject.js
+++ b/src/main/webapp/project/NewProject.js
@@ -143,7 +143,6 @@ const NewProject = hh(class NewProject extends Component {
     project.attestation = this.state.attestationFormData.attestation;
     let extraProperties = [];
 
-    extraProperties.push({name: 'pm', value: this.state.generalDataFormData.projectManager !== '' ? this.state.generalDataFormData.projectManager.key : null});
     extraProperties.push({name: 'affiliations', value: isEmpty(this.state.generalDataFormData.affiliations.value) ? null : JSON.stringify(this.state.generalDataFormData.affiliations)});
     extraProperties.push({name: 'affiliationOther', value: this.state.generalDataFormData.affiliationOther !== '' ? this.state.generalDataFormData.affiliationOther : null});
     extraProperties.push({name: 'projectTitle', value: this.state.generalDataFormData.pTitle !== '' ? this.state.generalDataFormData.pTitle : null});
@@ -158,6 +157,14 @@ const NewProject = hh(class NewProject extends Component {
         extraProperties.push({ name: 'pi', value: pi.key });
       });
     }
+
+    let pms = this.state.generalDataFormData.projectManagers;
+    if (pms !== null && pms.length > 0) {
+      pms.map((pi, idx) => {
+        extraProperties.push({ name: 'pm', value: pi.key });
+      });
+    }
+
     let collaborators = this.state.generalDataFormData.collaborators;
     if (collaborators !== null && collaborators.length > 0) {
       collaborators.map((collaborator, idx) => {

--- a/src/main/webapp/project/NewProjectGeneralData.js
+++ b/src/main/webapp/project/NewProjectGeneralData.js
@@ -31,7 +31,7 @@ export const NewProjectGeneralData = hh(class NewProjectGeneralData extends Comp
     this.loadUsersOptions = this.loadUsersOptions.bind(this);
     this.state = {
       formData: {
-        projectManager: '',
+        projectManagers: [],
         piNames: [],
         affiliations: '',
         affiliationOther: '',
@@ -43,7 +43,7 @@ export const NewProjectGeneralData = hh(class NewProjectGeneralData extends Comp
         collaborators: []
       },
       formerData: {
-        projectManager: '',
+        projectManager: [],
         piNames: [],
         affiliations: '',
         affiliationOther: '',
@@ -90,14 +90,6 @@ export const NewProjectGeneralData = hh(class NewProjectGeneralData extends Comp
     this.props.removeErrorMessage();
   };
 
-  handleProjectManagerChange = (data, action) => {
-    this.setState(prev => {
-      prev.formData.projectManager = data;
-      return prev;
-    }, () => this.props.updateForm(this.state.formData, 'projectManager'));
-    this.props.removeErrorMessage();
-  };
-
   handleSelectChange = (field) => () => (selectedOption) => {
     this.setState(prev => {
         prev.formData[field] = selectedOption;
@@ -137,14 +129,25 @@ export const NewProjectGeneralData = hh(class NewProjectGeneralData extends Comp
     this.setState(prev => {
       prev.formData.collaborators = data;
       return prev;
-    }, () => this.props.updateForm(this.state.formData, 'collaborators'));
-  };
+    }, () => {
+      this.props.updateForm(this.state.formData, 'collaborators');
+      this.props.removeErrorMessage();
+    }
+  )};
 
   handlePIChange = (data, action) => {
     this.setState(prev => {
       prev.formData.piNames = data;
       return prev;
     }, () => this.props.updateForm(this.state.formData, 'piNames'));
+  };
+
+  handlePMChange = (data, action) => {
+    this.setState(prev => {
+      prev.formData.projectManagers = data;
+      return prev;
+    }, () => this.props.updateForm(this.state.formData, 'projectManagers')
+    );
   };
 
   render() {
@@ -218,13 +221,13 @@ export const NewProjectGeneralData = hh(class NewProjectGeneralData extends Comp
           }),
           MultiSelect({
             id: "inputProjectManager",
-            label: "Broad Project Manager",
+            label: "Broad Project Managers",
             isDisabled: false,
             loadOptions: this.loadUsersOptions,
-            handleChange: this.handleProjectManagerChange,
-            value: this.state.formData.projectManager,
+            handleChange: this.handlePMChange,
+            value: this.state.formData.projectManagers,
             placeholder: "Start typing the Project Manager Name",
-            isMulti: false,
+            isMulti: true,
             edit: false
           }),
         ]),

--- a/src/main/webapp/project/NewProjectGeneralData.js
+++ b/src/main/webapp/project/NewProjectGeneralData.js
@@ -129,11 +129,8 @@ export const NewProjectGeneralData = hh(class NewProjectGeneralData extends Comp
     this.setState(prev => {
       prev.formData.collaborators = data;
       return prev;
-    }, () => {
-      this.props.updateForm(this.state.formData, 'collaborators');
-      this.props.removeErrorMessage();
-    }
-  )};
+    }, () => this.props.updateForm(this.state.formData, 'collaborators'));
+  };
 
   handlePIChange = (data, action) => {
     this.setState(prev => {

--- a/src/main/webapp/projectReview/ProjectReview.js
+++ b/src/main/webapp/projectReview/ProjectReview.js
@@ -631,7 +631,7 @@ const ProjectReview = hh(class ProjectReview extends Component {
   handleProjectManagerChange = (data, action) => {
     this.setState(prev => {
       if (data !== null) {
-        prev.formData.pmList = [data];
+        prev.formData.pmList = data;
         prev.formData.projectExtraProps.pm = data.key;
       } else {
         prev.formData.pmList = [];
@@ -988,14 +988,14 @@ const ProjectReview = hh(class ProjectReview extends Component {
 
           MultiSelect({
             id: "inputProjectManager",
-            label: "Broad Project Manager",
+            label: "Broad Project Managers",
             name: 'pmList',
             readOnly: this.state.readOnly,
             loadOptions: this.loadUsersOptions,
             handleChange: this.handleProjectManagerChange,
             value: this.state.formData.pmList,
             currentValue: this.state.current.pmList,
-            isMulti: false
+            isMulti: true
           })
         ]),
         Panel({ title: "Funding" }, [


### PR DESCRIPTION
## Addresses
https://github.com/broadinstitute/orsp-pub/compare/ORSP-30-MultiplePM?expand=1

## Changes
Modify select to allow users to choose more than one

## Testing
Describe for the reviewer how to test the specifics of this PR, both positive and negative cases.

---

- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Get a thumb from Belatrix
- [ ] **Submitter**: Get a thumb from ORSP representative
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
