### PR TITLE
ORSP-31 If a user has permission to access a sample data cohort, allow them to access the cohort via the search page or the "ORSP-ID" field in the navigation bar.

### DIFF
--- a/grails-app/services/org/broadinstitute/orsp/PermissionService.groovy
+++ b/grails-app/services/org/broadinstitute/orsp/PermissionService.groovy
@@ -33,12 +33,13 @@ class PermissionService implements UserInfo {
     // verifies if logged user belongs to some user list ....
     Boolean issueIsForbidden(Issue issue, String userName, boolean isAdmin, boolean isViewer) {
         Map<String, List<String>> extraProperties = issue.extraPropertiesMap
-        userHasIssueAccess(issue.reporter, extraProperties, userName, isAdmin, isViewer)
+        userHasIssueAccess(issue.reporter, extraProperties, userName, isAdmin, isViewer, false)
     }
 
-    Boolean userHasIssueAccess(String reporter, Map<String, List<String>> extraProperties, String userName, boolean isAdmin, boolean isViewer) {
+    Boolean userHasIssueAccess(String reporter, Map<String, List<String>> extraProperties, String userName, boolean isAdmin, boolean isViewer, Boolean isCollaboratorInRelatedProject) {
         boolean userHasAccess = (reporter == userName
                 || getIssueCollaborators(extraProperties)?.contains(userName)
+                || isCollaboratorInRelatedProject
                 || getIssuePMs(extraProperties).contains(userName)
                 || getIssuePIs(extraProperties).contains(userName)
                 || isAdmin


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/ORSP-31

## Changes
Verify if the current user exists as a collaborator in related projects in order to give access.

## Testing
Describe for the reviewer how to test the specifics of this PR, both positive and negative cases.

---

- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Get a thumb from Belatrix
- [ ] **Submitter**: Get a thumb from ORSP representative
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
