### PR TITLE
ORSP-34 Samples API missing from ORSP Dashboard

### DIFF
--- a/grails-app/services/org/broadinstitute/orsp/QueryService.groovy
+++ b/grails-app/services/org/broadinstitute/orsp/QueryService.groovy
@@ -467,7 +467,7 @@ class QueryService implements Status {
     }
 
     Collection<ConsentCollectionLink> findCollectionLinksWithSamples() {
-        Collection<ConsentCollectionLink> links = ConsentCollectionLink.findAllBySampleCollectionIdIsNotNull()
+        Collection<ConsentCollectionLink> links = ConsentCollectionLink.findAll()
         Collection<SampleCollection> sampleCollections = SampleCollection.
                 findAllByCollectionIdInList(links.collect { it.sampleCollectionId }.findAll { it && !it.isEmpty()})
         Collection<Issue> projects = Issue.findAllByProjectKeyInList(links.collect { it.projectKey })


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/ORSP-34

## Changes
Including null sample collections in te result.
## Testing
Describe for the reviewer how to test the specifics of this PR, both positive and negative cases.

---

- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Get a thumb from Belatrix
- [ ] **Submitter**: Get a thumb from ORSP representative
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
