### PR TITLE
ORSP-38-Project Approval

### DIFF
--- a/grails-app/views/notify/approval.gsp
+++ b/grails-app/views/notify/approval.gsp
@@ -2,7 +2,7 @@
     Your submission  <a href="${issueLink}">${issue.summary}</a> has been approved as
     <g:if test="${issue.type?.equals('IRB Project')}"> an  </g:if>
     <g:else> a </g:else> ${issue.type} in the ORSP Portal.
-    Please note this approval applies to your work as a Broad researcher only; if you maintain a dual  affiliation, we recommend contacting the IRB office at your home institution to determine if any submissions there are needed.
+    Please note that you are responsible for submission of significant proposed changes to this project to ensure they are consistent with this determination (e.g. the addition of new cohorts, a change in PI, new scientific activities).
 </p>
 <p>
     Thank you,


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/ORSP-38

## Changes
Update email template

## Testing
Go to Admin Only tab -> Project Status -> Approved. Email should be sent with the information provided in the email.

---

- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Get a thumb from Belatrix
- [ ] **Submitter**: Get a thumb from ORSP representative
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
