### PR TITLE
ORSP-72 Remove dul->duos functionality

### DIFF
--- a/grails-app/controllers/org/broadinstitute/orsp/api/DataUseController.groovy
+++ b/grails-app/controllers/org/broadinstitute/orsp/api/DataUseController.groovy
@@ -7,11 +7,9 @@ import org.broadinstitute.orsp.AuthenticatedController
 import org.broadinstitute.orsp.ConsentCollectionLink
 import org.broadinstitute.orsp.ConsentExportService
 import org.broadinstitute.orsp.ConsentService
-import org.broadinstitute.orsp.DataUseLetterService
 import org.broadinstitute.orsp.DataUseRestriction
 import org.broadinstitute.orsp.Issue
 import org.broadinstitute.orsp.SampleCollection
-import org.broadinstitute.orsp.StorageDocument
 import org.broadinstitute.orsp.consent.ConsentResource
 import org.broadinstitute.orsp.utils.UtilityClass
 import org.broadinstitute.orsp.webservice.PaginationParams
@@ -59,17 +57,11 @@ class DataUseController extends AuthenticatedController {
         try {
             DataUseRestriction restriction = DataUseRestriction.findById(params.id)
             Collection<String> sampleCollectionIds = queryService.findAllSampleCollectionIdsForConsent(restriction.getConsentGroupKey())
-            StorageDocument dataUseLetter = null
-            List<StorageDocument> duls = queryService.getDataUseLettersForConsent(restriction.getConsentGroupKey())
             Issue consent = queryService.findByKey(restriction.consentGroupKey)
-            if (duls && duls.size() > 0) {
-                dataUseLetter = storageProviderService.populateDocumentFileContent(duls.get(0))
-            }
             ConsentResource resource = consentExportService.exportConsent(
                     getUser(),
                     restriction,
                     sampleCollectionIds,
-                    dataUseLetter,
                     consent.summary)
             response.status = 200
             render([message: "Consent successfully exported to DUOS: $resource.name"] as JSON)

--- a/grails-app/services/org/broadinstitute/orsp/QueryService.groovy
+++ b/grails-app/services/org/broadinstitute/orsp/QueryService.groovy
@@ -1298,32 +1298,6 @@ class QueryService implements Status {
         ]
     }
 
-    /**
-     * Find all data use documents for a consent, ordered by most recent first.
-     *
-     * @param consentKey The consent group's project key
-     * @return Ordered list of storage documents of the DUL type.
-     */
-    List<StorageDocument> getDataUseLettersForConsent(String consentKey) {
-        final String query =
-                ' select d.* ' +
-                ' from storage_document d ' +
-                ' where d.project_key = :projectKey ' +
-                ' and d.file_type = :fileType ' +
-                ' and d.deleted = 0 '+
-                ' order by d.creation_date desc '
-        SessionFactory sessionFactory = grailsApplication.getMainContext().getBean('sessionFactory')
-        final session = sessionFactory.currentSession
-        final SQLQuery sqlQuery = session.createSQLQuery(query)
-        final results = sqlQuery.with {
-            addEntity(StorageDocument)
-            setString('projectKey', consentKey)
-            setString('fileType', ConsentGroupController.DU_LETTER)
-            list()
-        }
-        results
-    }
-
     Collection<StorageDocument> getAttachmentsForProject(String projectKey) {
         SessionFactory sessionFactory = grailsApplication.getMainContext().getBean('sessionFactory')
         final session = sessionFactory.currentSession

--- a/src/test/groovy/org/broadinstitute/orsp/ConsentExportServiceSpec.groovy
+++ b/src/test/groovy/org/broadinstitute/orsp/ConsentExportServiceSpec.groovy
@@ -103,7 +103,7 @@ class ConsentExportServiceSpec extends Specification implements DataTest, Servic
         1 * consentService.postConsent(*_) >> "location"
         0 * consentService.updateConsent(*_) >> true
         1 * consentService.postConsentAssociations(*_) >> true
-        3 * persistenceService.saveEvent(*_) >> new Event()
+        2 * persistenceService.saveEvent(*_) >> new Event()
         resource != null
     }
 
@@ -176,7 +176,7 @@ class ConsentExportServiceSpec extends Specification implements DataTest, Servic
         0 * consentService.postConsent(*_) >> "location"
         1 * consentService.updateConsent(*_) >> true
         1 * consentService.postConsentAssociations(*_) >> true
-        3 * persistenceService.saveEvent(*_) >> new Event()
+        2 * persistenceService.saveEvent(*_) >> new Event()
         resource != null
     }
 

--- a/src/test/groovy/org/broadinstitute/orsp/ConsentServiceUnitSpec.groovy
+++ b/src/test/groovy/org/broadinstitute/orsp/ConsentServiceUnitSpec.groovy
@@ -5,13 +5,11 @@ import com.google.gson.JsonElement
 import com.google.gson.JsonParser
 import grails.testing.services.ServiceUnitTest
 import groovy.util.logging.Slf4j
-import org.apache.commons.io.IOUtils
 import org.broadinstitute.orsp.config.ConsentConfiguration
 import org.broadinstitute.orsp.consent.ConsentResource
 import org.broadinstitute.orsp.consent.DataUseDTO
 import org.broadinstitute.orsp.webservice.OntologyTerm
 import org.junit.Rule
-import spock.lang.Ignore
 
 import java.text.SimpleDateFormat
 
@@ -57,41 +55,6 @@ class ConsentServiceUnitSpec extends BaseSpec implements ServiceUnitTest<Consent
 
         then:
         assertNotNull(location)
-    }
-
-    /**
-     * TODO: See:
-     * https://stackoverflow.com/questions/18020437/no-multipartconfig-for-servlet-error-from-jetty-using-scalatra
-     * Getting this error from missing a config in the jetty that gets spun up for wiremock.
-     * ...
-     * WARN [09/12/2018 06:44:49.918] org.eclipse.jetty.server.HttpChannel - /consent/consent-id/dul
-     * java.lang.IllegalStateException: No multipart config for servlet
-     * 	at org.eclipse.jetty.server.Request.getParts(Request.java:2331)
-     * 	at org.eclipse.jetty.server.Request.getParts(Request.java:2319)
-     * 	at com.github.tomakehurst.wiremock.servlet.WireMockHttpServletRequestAdapter.safelyGetRequestParts(WireMockHttpServletRequestAdapter.java:295)
-     */
-    @Ignore
-    void "Post a Data Use Letter"() {
-        given:
-        String consentUrl = "http://localhost:${wireMockRule.port()}/consent"
-        String consentLocation = consentUrl + "/consent-id"
-        service.consentConfiguration.url = consentUrl
-        wireMockRule.resetAll()
-        // Post Consent Data Use Letter endpoint
-        stubFor(post(urlEqualTo("/consent/consent-id/dul"))
-                .willReturn(aResponse()
-                .withStatus(200)
-                .withHeader("Content-Type", "application/json")
-                .withHeader("Location", consentLocation)
-                .withBody()))
-        InputStream is = IOUtils.toInputStream("Test", "UTF-8")
-        String fileName = "test.txt"
-
-        when:
-        def dulResponse = service.postDataUseLetter(consentLocation, is, fileName)
-
-        then:
-        assertNotNull(dulResponse)
     }
 
     void "ConsentService.stripTextOfHtml works in covered cases"() {


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/ORSP-72

## Changes
This PR removes all data use letter functionality that pushes consent documents to DUOS.

## Testing
View existing consent pages and ensure that there are no regressions.

---

- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Get a thumb from Belatrix
- [ ] **Submitter**: Get a thumb from ORSP representative
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
