### PR TITLE
Update Fundings.js

### DIFF
--- a/src/main/webapp/components/Fundings.js
+++ b/src/main/webapp/components/Fundings.js
@@ -242,7 +242,7 @@ export const Fundings = hh(class Fundings extends Component {
                       value: this.props.edit ? rd.future.identifier: rd.identifier,
                       currentValue: this.props.edit ? current[idx].current.identifier : rd.identifier,
                       disabled: false,
-                      required: rd.future.sponsor.value === 'federal_prime' || rd.future.sponsor.value === 'federal_sub-award' ? true : false,
+                      required: rd.source.value === 'federal_prime' || rd.source.value === 'federal_sub-award' ? true : false,
                       onChange: this.handleFundingChange,
                       readOnly: this.props.readOnly
                     })


### PR DESCRIPTION
Funding Project field

## Addresses
https://broadinstitute.atlassian.net/browse/CRIC-1261

## Changes
Changes to funding fields on Project Information page: 
1) Remove "Internal Broad" from the dropdown menu and replace it with "Broad Institutional Award" 
2) Make "Sponsor Name" a required field. Is it possible to only do this for new applications so that we will not have to enter a sponsor name each time a legacy project is updated? If that's not feasible, is it possible to auto-populate existing projects with a blank "Sponsor Name" field with "legacy?" 
3) Change "Sponsor Name" field to "Sponsor Name/Payer" 4) Make "Award Number/Identifier" a required field when someone chooses "Federal Prime" or Federal Sub-Award" from the dropdown menu. If that logic isn't possible, include text under "Award Number/Identifier" that says, "Required for Federal Prime and Federal Subawards." 
Activity

## Testing
Describe for the reviewer how to test the specifics of this PR, both positive and negative cases.

---

- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Get a thumb from Belatrix
- [ ] **Submitter**: Get a thumb from ORSP representative
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
