### PR TITLE
Update Fundings.js

### DIFF
--- a/src/main/webapp/components/Fundings.js
+++ b/src/main/webapp/components/Fundings.js
@@ -226,7 +226,7 @@ export const Fundings = hh(class Fundings extends Component {
                       value: this.props.edit ? rd.future.sponsor : rd.sponsor,
                       currentValue: this.props.edit ? current[idx].current.sponsor : rd.sponsor,
                       disabled: false,
-                      required: true,
+                      required: this.props.edit ? false : true,
                       onChange: this.handleFundingChange,
                       readOnly: this.props.readOnly
                     })


### PR DESCRIPTION
CRIC-1261-Funding Project

## Addresses
https://broadinstitute.atlassian.net/browse/CRIC-1261

## Changes
Changes to funding fields on Project Information page: 
1) Remove "Internal Broad" from the dropdown menu and replace it with "Broad Institutional Award" 
2) Make "Sponsor Name" a required field. Is it possible to only do this for new applications so that we will not have to enter a sponsor name each time a legacy project is updated? If that's not feasible, is it possible to auto-populate existing projects with a blank "Sponsor Name" field with "legacy?" 
3) Change "Sponsor Name" field to "Sponsor Name/Payer" 4) Make "Award Number/Identifier" a required field when someone chooses "Federal Prime" or Federal Sub-Award" from the dropdown menu. If that logic isn't possible, include text under "Award Number/Identifier" that says, "Required for Federal Prime and Federal Subawards." 