### PR TITLE
Update Fundings.js

### DIFF
--- a/src/main/webapp/components/Fundings.js
+++ b/src/main/webapp/components/Fundings.js
@@ -163,21 +163,20 @@ export const Fundings = hh(class Fundings extends Component {
     }
     return identifierHasError;
   };
-  requiredIdentifierField(rd) { console.log('Function trigger');
-    if (this.props.edit){ console.log(rd+'rd Edit');
-    if (rd.future.source.value == 'federal_prime' || rd.future.source.value == 'federal_sub-award') {console.log(rd+'First if');
+  requiredIdentifierField(rd) { 
+    if (this.props.edit){
+    if (rd.future.source.value == 'federal_prime' || rd.future.source.value == 'federal_sub_award') {
     return true;
-    } else { console.log('First else');
+    } else {
     return false;
     }
-   } else { console.log(rd+'rd non-edit');
-   if (rd.source.value == 'federal_prime' || rd.source.value == 'federal_sub-award' ) { console.log(rd+'Second if');
-  return true;
-  } else { console.log('Second else');
-  return false;
-  }
-  }
-  }
+    } else {
+    if (rd.source.value == 'federal_prime' || rd.source.value == 'federal_sub_award' ) {
+    return true;
+    } else {
+    return false;
+    }
+    }
   render() {
     let {
       fundings = [],


### PR DESCRIPTION
## Addresses
CRIC-1261 ORSP - Changes to funding fields on Project Information page

## Changes
Changes to funding fields on Project Information page: 
1) Remove "Internal Broad" from the dropdown menu and replace it with "Broad Institutional Award" 
2) Make "Sponsor Name" a required field. Is it possible to only do this for new applications so that we will not have to enter a sponsor name each time a legacy project is updated? If that's not feasible, is it possible to auto-populate existing projects with a blank "Sponsor Name" field with "legacy?" 
3) Change "Sponsor Name" field to "Sponsor Name/Payer" 4) Make "Award Number/Identifier" a required field when someone chooses "Federal Prime" or Federal Sub-Award" from the dropdown menu. If that logic isn't possible, include text under "Award Number/Identifier" that says, "Required for Federal Prime and Federal Subawards."
