### PR TITLE
Update Fundings.js

### DIFF
--- a/src/main/webapp/components/Fundings.js
+++ b/src/main/webapp/components/Fundings.js
@@ -165,16 +165,17 @@ export const Fundings = hh(class Fundings extends Component {
   };
   requiredIdentifierField(rd) { 
     if (this.props.edit){
-    if (rd.future.source.value == 'federal_prime' || rd.future.source.value == 'federal_sub_award') {
+    if (rd.future.source.value == 'federal_sub-award') {
     return true;
     } else {
     return false;
     }
     } else {
-    if (rd.source.value == 'federal_prime' || rd.source.value == 'federal_sub_award' ) {
+    if (rd.source.value == 'federal_sub-award' ) {
     return true;
     } else {
     return false;
+    }
     }
     }
   render() {


### PR DESCRIPTION
## Addresses
CRIC-1261-ORSP - Changes to funding fields on Project Information page

## Changes
Changes to funding fields on Project Information page: 
1) Remove "Internal Broad" from the dropdown menu and replace it with "Broad Institutional Award" 
2) Make "Sponsor Name" a required field. Is it possible to only do this for new applications so that we will not have to enter a sponsor name each time a legacy project is updated? If that's not feasible, is it possible to auto-populate existing projects with a blank "Sponsor Name" field with "legacy?" 
3) Change "Sponsor Name" field to "Sponsor Name/Payer" 4) Make "Award Number/Identifier" a required field when someone chooses "Federal Prime" or Federal Sub-Award" from the dropdown menu. If that logic isn't possible, include text under "Award Number/Identifier" that says, "Required for Federal Prime and Federal Subawards." 
