### PR TITLE
Cric 1261 new

### DIFF
--- a/src/main/groovy/org/broadinstitute/orsp/Fields.groovy
+++ b/src/main/groovy/org/broadinstitute/orsp/Fields.groovy
@@ -20,7 +20,7 @@ class Fields {
     }
 
     public static final List<String> FUNDING_SOURCES =
-            ["Federal Prime", "Federal Sub-award", "Internal Broad", "Purchase Order", "Corporate Funding", "Foundation", "Philanthropy", "Other"]
+            ["Federal Prime", "Federal Sub-award", "Broad Institutional Award", "Purchase Order", "Corporate Funding", "Foundation", "Philanthropy", "Other"]
 
     public static final Map<String, String> NOT_RESEARCH_MAP = [
             "10133":"This project does not constitute research.",

--- a/src/main/webapp/components/Fundings.js
+++ b/src/main/webapp/components/Fundings.js
@@ -158,7 +158,7 @@ export const Fundings = hh(class Fundings extends Component {
   getIdentifierError = (element) => {
     let identifierHasError = false;
     const source = this.props.edit ? element.future.source : element.source;
-    if (this.props.fundingAwardNumberError && source.value === 'federal_prime' && source.value === 'federal_sub-award') {
+    if (this.props.fundingAwardNumberError && source.value === 'federal_prime' || source.value === 'federal_sub-award') {
       identifierHasError = this.props.edit ? isEmpty(element.future.identifier): isEmpty(element.identifier)
     }
     return identifierHasError;

--- a/src/main/webapp/components/Fundings.js
+++ b/src/main/webapp/components/Fundings.js
@@ -158,26 +158,12 @@ export const Fundings = hh(class Fundings extends Component {
   getIdentifierError = (element) => {
     let identifierHasError = false;
     const source = this.props.edit ? element.future.source : element.source;
-    if (this.props.fundingAwardNumberError && source.value === 'federal_prime') {
+    if (this.props.fundingAwardNumberError && source.value === 'federal_prime' && source.value === 'federal_sub-award') {
       identifierHasError = this.props.edit ? isEmpty(element.future.identifier): isEmpty(element.identifier)
     }
     return identifierHasError;
   };
-  requiredIdentifierField(rd) { 
-    if (this.props.edit){
-    if (rd.future.source.value == 'federal_sub-award') {
-    return true;
-    } else {
-    return false;
-    }
-    } else {
-    if (rd.source.value == 'federal_sub-award' ) {
-    return true;
-    } else {
-    return false;
-    }
-    }
-    }
+
   render() {
     let {
       fundings = [],
@@ -256,7 +242,7 @@ export const Fundings = hh(class Fundings extends Component {
                       value: this.props.edit ? rd.future.identifier: rd.identifier,
                       currentValue: this.props.edit ? current[idx].current.identifier : rd.identifier,
                       disabled: false,
-                      required: this.requiredIdentifierField(rd),
+                      required: false,
                       onChange: this.handleFundingChange,
                       readOnly: this.props.readOnly
                     })


### PR DESCRIPTION
## Addresses
CRIC-1261-ORSP - Changes to funding fields on Project Information page

## Changes
Changes to funding fields on Project Information page:

 1. Remove "Internal Broad" from the dropdown menu and replace it with "Broad Institutional Award"
 2. Make "Sponsor Name" a required field. Is it possible to only do this for new applications so that we will not have to enter a sponsor name each time a legacy project is updated? If that's not feasible, is it possible to auto-populate existing projects with a blank "Sponsor Name" field with "legacy?"
 3. Change "Sponsor Name" field to "Sponsor Name/Payer" 4) Make "Award Number/Identifier" a required field when someone chooses "Federal Prime" or Federal Sub-Award" from the dropdown menu. If that logic isn't possible, include text under "Award Number/Identifier" that says, "Required for Federal Prime and Federal Subawards."