### PR TITLE
Submit to IRB

### DIFF
--- a/src/main/webapp/CollapsiblePanel/SampleDataCohortsCollapsibleHeader.js
+++ b/src/main/webapp/CollapsiblePanel/SampleDataCohortsCollapsibleHeader.js
@@ -23,6 +23,10 @@ const styles = {
     backgroundColor: '#F0E5A9',
     color: '#333333'
   },
+  statusPendingIRBReview: {
+    backgroundColor: '#ffb499',
+    color: '#4d1400'
+  },
   link: {
       textDecoration: "none",
       display: "inline-block",
@@ -34,10 +38,12 @@ const styles = {
 
 const approved = { ...styles.statusBase, ...styles.statusApproved};
 const pending = { ...styles.statusBase, ...styles.statusPending};
+const pendingIRBReview = { ...styles.statusBase, ...styles.statusPendingIRBReview };
 
 const STATUS = {
   approved: 'approved',
-  pending: 'pending'
+  pending: 'pending',
+  pendingIRBReview: 'pending irb review'
 };
 
 export const SampleDataCohortsCollapsibleHeader = hh(class SampleDataCohortsCollapsibleHeader extends Component {
@@ -61,7 +67,7 @@ export const SampleDataCohortsCollapsibleHeader = hh(class SampleDataCohortsColl
   };
 
   render() {
-    const { unlinkHandler, rejectHandler, approveHandler, requestClarificationHandler } = this.props.element.customHandlers;
+    const { unlinkHandler, rejectHandler, approveHandler, submittedToIRBHandler, requestClarificationHandler } = this.props.element.customHandlers;
     const { projectKey, summary} = this.props.element.consent;
     const  status = isEmpty(this.props.element.consent.status) ? '' : this.props.element.consent.status.toLowerCase();
 
@@ -74,19 +80,25 @@ export const SampleDataCohortsCollapsibleHeader = hh(class SampleDataCohortsColl
             },[ i({ className: 'glyphicon glyphicon-chevron-down' },[])
           ])
         ]),
-        span({ style: status === STATUS.approved ? approved : pending },
-          [ status === STATUS.approved ? 'Approved' : 'Pending'
+        span({ style: status === STATUS.approved ? approved : status === STATUS.pendingIRBReview ? pendingIRBReview : pending },
+          [ status === STATUS.approved ? 'Approved' : status === STATUS.pendingIRBReview ? 'Pending IRB Review' : 'Pending ORSP Review'
         ]),
         div({className: 'panel-title'}, [
           div({className: 'cta-container'}, [
             button({
-              isRendered: component.isAdmin && (status === STATUS.pending || isEmpty(status)),
+              isRendered: component.isAdmin && (status === STATUS.pending || status === STATUS.pendingIRBReview || isEmpty(status)),
               className: 'btn btn-default btn-sm confirmationModal',
               style: styles.pointer.auto,
               onClick: (e) => approveHandler(e, projectKey)
             },['Approve']),
             button({
               isRendered: component.isAdmin && (status === STATUS.pending || isEmpty(status)),
+              className: 'btn btn-default btn-sm confirmationModal',
+              style: styles.pointer.auto,
+              onClick: (e) => submittedToIRBHandler(e, projectKey)
+            },['Submitted to IRB']),
+            button({
+              isRendered: component.isAdmin && (status === STATUS.pending || status === STATUS.pendingIRBReview || isEmpty(status)),
               className: 'btn btn-default btn-sm confirmationModal',
               style: styles.pointer.auto,
               onClick: (e) => rejectHandler(e, projectKey)

--- a/src/main/webapp/projectContainer/ConsentGroups.js
+++ b/src/main/webapp/projectContainer/ConsentGroups.js
@@ -124,6 +124,11 @@ const ConsentGroups = hh(class ConsentGroups extends Component {
         this.getProjectConsentGroups();
         this.closeConfirmationModal();
       });
+    } else if (this.state.action === "submit to IRB") {
+      ConsentCollectionLink.submittedToIRBLink(this.state.issue.projectKey, this.state.actionConsentKey).then(resp => {
+        this.getProjectConsentGroups();
+        this.closeConfirmationModal();
+      });
     } else if (this.state.action === 'remove') {
       DocumentHandler.deleteAttachmentByUuid(this.state.fileIdToRemove).
       then(resp => {
@@ -190,6 +195,15 @@ const ConsentGroups = hh(class ConsentGroups extends Component {
     });
   };
 
+  submittedToIRB = (e, consentKey) => {
+    e.stopPropagation();
+    this.setState(prev => {
+      prev.action = 'submit to IRB';
+      prev.showConfirmationModal = true;
+      prev.actionConsentKey = consentKey;
+      return prev;
+  }
+
   reject = (e, consentKey) => {
     e.stopPropagation();
     this.setState(prev => {
@@ -239,6 +253,7 @@ const ConsentGroups = hh(class ConsentGroups extends Component {
             approveHandler: this.approve,
             rejectHandler: this.reject,
             unlinkHandler: this.unlink,
+            submittedToIRBHandler: this.submittedToIRB,
             requestClarificationHandler: this.requestClarification
           }
         }

--- a/src/main/webapp/util/UrlConstants.js
+++ b/src/main/webapp/util/UrlConstants.js
@@ -93,6 +93,7 @@ export const UrlConstants = {
   sampleConsentLinkUrl: context + '/api/sample-consent-link',
   sampleBreakLinkUrl: context + '/api/break-link',
   sampleApproveLinkUrl: context + '/api/approve-link',
+  sampleSubmitToIRBLinkURL: context + '/api/submit-to-irb-link',
   historyUrl: context + '/api/history',
   restrictionUrl: context + '/dataUse/restriction',  
   showRestrictionUrl: context + '/dataUse/view',

--- a/src/main/webapp/util/ajax.js
+++ b/src/main/webapp/util/ajax.js
@@ -441,6 +441,10 @@ export const ConsentCollectionLink = {
     return axios.post(UrlConstants.sampleBreakLinkUrl + '?projectKey='+ projectKey +"&consentKey=" + consentKey + "&type=" + actionKey);
   },
 
+  submittedToIRBLink(projectKey, consentKey) {
+    return axios.put(UrlConstants.sampleSubmitToIRBLinkURL + '?projectKey='+ projectKey +"&consentKey=" + consentKey);
+  }
+
   approveLink(projectKey, consentKey) {
     return axios.put(UrlConstants.sampleApproveLinkUrl + '?projectKey='+ projectKey +"&consentKey=" + consentKey);
   },


### PR DESCRIPTION
## Addresses
CRIC-1260 ORSP Portal Update - Implement new status/button for Submit to IRB

## Changes
1) Changes to  sample data cohort workflow: 1) Add a "Submitted to IRB" button to the left of "Reject" 
2) Change the default "Pending" status on the right (in yellow) to "Pending ORSP Review" when someone submits a sample/data cohort
3) Add a new status (in orange/different color), "Pending IRB Review," when ORSP hits the new "Submitted to IRB" button on the left. 
4) Update the email text that users receive when they submit a sample/data cohort.  Change current text "A new Consent Group Record xxxx has been created in the ORSP Portal and is pending ORSP review and approval." to new text: "A new Sample/Data Cohort Record xxxx has been created in the ORSP Portal and is pending ORSP review and approval.  Please note that work with the samples or data should not start until the sample/data cohort has been approved by ORSP and/or the IRB-of-record (as needed).  Approval status is shown in the sample/data cohort tab." 