### PR TITLE
Revert "Bump gradle-clover-plugin from 2.2.0 to 3.0.3"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         classpath "com.bertramlabs.plugins:asset-pipeline-gradle:3.0.11"
         classpath "org.grails.plugins:views-gradle:1.1.6"
         classpath "gradle.plugin.com.srcclr:gradle:3.0.4"
-        classpath 'com.bmuschko:gradle-clover-plugin:3.0.3'
+        classpath 'com.bmuschko:gradle-clover-plugin:2.2.0'
         classpath 'org.grails.plugins:database-migration:3.0.4'
     }
 }


### PR DESCRIPTION
Reverts broadinstitute/orsp-pub#953