### PR TITLE
Revert "Bump asset-pipeline-grails from 3.0.11 to 3.4.6"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ dependencies {
     profile "org.grails.profiles:web"
     runtime "org.glassfish.web:el-impl:2.2.1-b05"
     runtime "org.apache.tomcat:tomcat-jdbc:10.0.23"
-    runtime "com.bertramlabs.plugins:asset-pipeline-grails:3.4.6"
+    runtime "com.bertramlabs.plugins:asset-pipeline-grails:3.0.11"
     testRuntime "com.h2database:h2"
     testCompile "org.grails:grails-gorm-testing-support"
     testCompile "org.grails.plugins:geb"


### PR DESCRIPTION
Reverts broadinstitute/orsp-pub#1009