### PR TITLE
Revert "Bump gradle-node-plugin from 1.1.1 to 1.3.1 (#1018)"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
     dependencies {
         classpath "org.grails:grails-gradle-plugin:$grailsVersion"
-        classpath "com.moowork.gradle:gradle-node-plugin:1.3.1"
+        classpath "com.moowork.gradle:gradle-node-plugin:1.1.1"
         classpath "org.grails.plugins:hibernate5:${gormVersion-".RELEASE"}"
         classpath "com.bertramlabs.plugins:asset-pipeline-gradle:3.4.6"
         classpath "org.grails.plugins:views-gradle:1.1.6"


### PR DESCRIPTION
This reverts commit f1545d0301cdd8639fdd035b73e6c012391a7671.

## Addresses
Please link to Jira ticket here

## Changes
Include a high level summary of the changes and what they are intended for.

## Testing
Describe for the reviewer how to test the specifics of this PR, both positive and negative cases.

---

- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Get a thumb from Belatrix
- [ ] **Submitter**: Get a thumb from ORSP representative
- [ ] **Submitter**: Merge to develop using github's "Squash and Merge" feature
- [ ] **Submitter**: Delete branch after merge
