### PR TITLE
Docker image deprecation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 executors:
   cloud-sdk:
     docker:
-      - image: google/cloud-sdk
+      - image: cimg/gcp:2022.08.1
 commands:
   build-env:
     description: "Build/push image to GCR"


### PR DESCRIPTION
CRIC-2182
Docker image updated from google/cloud-sdk to cimg/gcp:2022.08.1