### PR TITLE
 Docker image deprecation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 executors:
   cloud-sdk:
     docker:
-      - image: google/cloud-sdk
+      - image: cimg/gcp:2022.08.1
 commands:
   build-env:
     description: "Build/push image to GCR"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ commands:
       - run:
           name: Setup Google Cloud SDK
           command: |
-            apt-get install -qq -y gettext
+            sudo apt-get install -qq -y gettext
             echo "$<< parameters.sa_key_name >>" > ${HOME}/gcloud-service-key.json
             gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
             gcloud --quiet config set project ${GOOGLE_PROJECT}
@@ -109,7 +109,7 @@ commands:
       - run:
           name: Setup Google Cloud SDK
           command: |
-            apt-get install -qq -y gettext
+            sudo apt-get install -qq -y gettext
             echo "$<< parameters.sa_key_name >>" > ${HOME}/gcloud-service-key.json
             gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
             gcloud --quiet config set project ${GOOGLE_PROJECT}


### PR DESCRIPTION
CRIC-2182
Docker image updated from google/cloud-sdk to
cimg/gcp:2022.08.1

