### PR TITLE
Cric 2182 docker image deprecation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ commands:
       - run:
           name: Setup Google Cloud SDK
           command: |
-            sudo apt-get install -qq -y gettext
+            apt-get install -qq -y gettext
             echo "$<< parameters.sa_key_name >>" > ${HOME}/gcloud-service-key.json
             gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
             gcloud --quiet config set project ${GOOGLE_PROJECT}
@@ -109,7 +109,7 @@ commands:
       - run:
           name: Setup Google Cloud SDK
           command: |
-            sudo apt-get install -qq -y gettext
+            apt-get install -qq -y gettext
             echo "$<< parameters.sa_key_name >>" > ${HOME}/gcloud-service-key.json
             gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
             gcloud --quiet config set project ${GOOGLE_PROJECT}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 executors:
   cloud-sdk:
     docker:
-      - image: cimg/gcp:2022.08.1
+      - image: google/cloud-sdk:530.0.0
 commands:
   build-env:
     description: "Build/push image to GCR"
@@ -38,7 +38,7 @@ commands:
       - run:
           name: Setup Google Cloud SDK
           command: |
-            sudo apt-get install -qq -y gettext
+            apt-get install -qq -y gettext
             echo "$<< parameters.sa_key_name >>" > ${HOME}/gcloud-service-key.json
             gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
             gcloud --quiet config set project ${GOOGLE_PROJECT}
@@ -109,7 +109,7 @@ commands:
       - run:
           name: Setup Google Cloud SDK
           command: |
-            sudo apt-get install -qq -y gettext
+            apt-get install -qq -y gettext
             echo "$<< parameters.sa_key_name >>" > ${HOME}/gcloud-service-key.json
             gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
             gcloud --quiet config set project ${GOOGLE_PROJECT}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 executors:
   cloud-sdk:
     docker:
-      - image: google/cloud-sdk
+      - image: cimg/gcp:2022.08.1
 commands:
   build-env:
     description: "Build/push image to GCR"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ commands:
       - run:
           name: Setup Google Cloud SDK
           command: |
-            apt-get install -qq -y gettext
+            sudo apt-get install -qq -y gettext
             echo "$<< parameters.sa_key_name >>" > ${HOME}/gcloud-service-key.json
             gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
             gcloud --quiet config set project ${GOOGLE_PROJECT}
@@ -109,7 +109,7 @@ commands:
       - run:
           name: Setup Google Cloud SDK
           command: |
-            apt-get install -qq -y gettext
+            sudo apt-get install -qq -y gettext
             echo "$<< parameters.sa_key_name >>" > ${HOME}/gcloud-service-key.json
             gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
             gcloud --quiet config set project ${GOOGLE_PROJECT}


### PR DESCRIPTION
## Addresses
https://broadbits.atlassian.net/browse/CRIC-2182

## Changes
Docker image updated from
google/cloud-sdk to google/cloud-sdk:530.0.0